### PR TITLE
fix: update bounty status to completed in complete_bounty

### DIFF
--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,6 +1,4 @@
-use soroban_sdk::{
-    contract, contractimpl, token::TokenClient, Address, BytesN, Env, Symbol,
-};
+use soroban_sdk::{contract, contractimpl, token::TokenClient, Address, BytesN, Env, Symbol};
 
 use crate::events;
 use crate::storage;
@@ -8,6 +6,7 @@ use crate::types::{Bounty, Contributor};
 
 const STATUS_OPEN: &str = "open";
 const STATUS_IN_PROGRESS: &str = "in_progress";
+const STATUS_COMPLETED: &str = "completed";
 
 fn generate_bounty_id(env: &Env) -> BytesN<32> {
     let count = storage::get_bounty_count(env);
@@ -71,7 +70,7 @@ impl MergeMintContract {
     pub fn complete_bounty(env: Env, verifier: Address, bounty_id: BytesN<32>) {
         verifier.require_auth();
 
-        let bounty = storage::get_bounty(&env, &bounty_id).expect("bounty not found");
+        let mut bounty = storage::get_bounty(&env, &bounty_id).expect("bounty not found");
         let assignee = bounty.assignee.clone().expect("bounty has no assignee");
 
         let token = TokenClient::new(&env, &bounty.reward_token);
@@ -89,6 +88,9 @@ impl MergeMintContract {
         contributor.contribution_count += 1;
 
         storage::store_contributor(&env, &assignee, &contributor);
+
+        bounty.status = Symbol::new(&env, STATUS_COMPLETED);
+        storage::store_bounty(&env, &bounty_id, &bounty);
 
         events::emit_bounty_completed(&env, &bounty_id, &assignee);
         events::emit_reward_paid(&env, &bounty_id, &assignee, &bounty.reward_amount);

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,9 +1,6 @@
 #![cfg(test)]
 
-use soroban_sdk::{
-    testutils::{Address as _, BytesN as _},
-    Address, Env, Symbol,
-};
+use soroban_sdk::{testutils::Address as _, token, Address, Env, Symbol};
 
 use crate::contract::MergeMintContract;
 use crate::contract::MergeMintContractClient;
@@ -96,20 +93,37 @@ fn test_bounty_count() {
 
 #[test]
 fn test_complete_bounty_updates_status() {
-    let (env, creator, contributor, _verifier) = setup_test();
+    let (env, creator, contributor, verifier) = setup_test();
 
     let contract_id = env.register_contract(None, MergeMintContract);
     let client = MergeMintContractClient::new(&env, &contract_id);
+
+    let reward_amount: i128 = 1000;
+    let token_contract = env.register_stellar_asset_contract_v2(verifier.clone());
+    let reward_token = token_contract.address();
+    let token_admin = token::StellarAssetClient::new(&env, &reward_token);
+    token_admin.mint(&verifier, &reward_amount);
 
     let bounty_id = client.create_bounty(
         &creator,
         &Symbol::new(&env, "bounty_c"),
         &Symbol::new(&env, "desc_c"),
-        &1000,
-        &Address::generate(&env),
+        &reward_amount,
+        &reward_token,
     );
 
     client.claim_bounty(&contributor, &bounty_id);
+    client.complete_bounty(&verifier, &bounty_id);
+
     let bounty = client.get_bounty(&bounty_id).unwrap();
     assert_eq!(bounty.assignee.unwrap(), contributor);
+    assert_eq!(bounty.status, Symbol::new(&env, "completed"));
+
+    let contributor_record = client.get_contributor(&contributor).unwrap();
+    assert_eq!(contributor_record.reputation, 10);
+    assert_eq!(contributor_record.total_earned, reward_amount);
+    assert_eq!(contributor_record.contribution_count, 1);
+
+    let token_client = token::TokenClient::new(&env, &reward_token);
+    assert_eq!(token_client.balance(&contributor), reward_amount);
 }


### PR DESCRIPTION
## Summary
- Persist bounty status as completed when complete_bounty succeeds.
- Extend the completion test to run the full claim/complete flow with a mock Stellar asset token.
- Verify completed status, contributor accounting, and reward token transfer.

## Tests
- cargo +stable-x86_64-pc-windows-gnu test`n  - 4 passed, 0 failed
  - Existing deprecation warnings remain in events/test helpers.

Closes #241