### PR TITLE
Split contract.rs into logical sub-modules (queries, mutations)

### DIFF
--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -1,0 +1,24 @@
+use soroban_sdk::{
+    contract, contractimpl, token::TokenClient, Address, BytesN, Env, Symbol,
+};
+
+use crate::events;
+use crate::storage;
+use crate::types::{Bounty, Contributor};
+
+const STATUS_OPEN: &str = "open";
+const STATUS_IN_PROGRESS: &str = "in_progress";
+
+fn generate_bounty_id(env: &Env) -> BytesN<32> {
+    let count = storage::get_bounty_count(env);
+    let mut buf = [0u8; 32];
+    let count_bytes = count.to_be_bytes();
+    buf[24..32].copy_from_slice(&count_bytes);
+    BytesN::from_array(env, &buf)
+}
+
+#[contract]
+pub struct MergeMintContract;
+
+include!("mutations.rs");
+include!("queries.rs");

--- a/src/contract/mutations.rs
+++ b/src/contract/mutations.rs
@@ -1,25 +1,3 @@
-use soroban_sdk::{
-    contract, contractimpl, token::TokenClient, Address, BytesN, Env, Symbol,
-};
-
-use crate::events;
-use crate::storage;
-use crate::types::{Bounty, Contributor};
-
-const STATUS_OPEN: &str = "open";
-const STATUS_IN_PROGRESS: &str = "in_progress";
-
-fn generate_bounty_id(env: &Env) -> BytesN<32> {
-    let count = storage::get_bounty_count(env);
-    let mut buf = [0u8; 32];
-    let count_bytes = count.to_be_bytes();
-    buf[24..32].copy_from_slice(&count_bytes);
-    BytesN::from_array(env, &buf)
-}
-
-#[contract]
-pub struct MergeMintContract;
-
 #[contractimpl]
 impl MergeMintContract {
     pub fn create_bounty(
@@ -92,17 +70,5 @@ impl MergeMintContract {
 
         events::emit_bounty_completed(&env, &bounty_id, &assignee);
         events::emit_reward_paid(&env, &bounty_id, &assignee, &bounty.reward_amount);
-    }
-
-    pub fn get_bounty(env: Env, bounty_id: BytesN<32>) -> Option<Bounty> {
-        storage::get_bounty(&env, &bounty_id)
-    }
-
-    pub fn get_contributor(env: Env, address: Address) -> Option<Contributor> {
-        storage::get_contributor(&env, &address)
-    }
-
-    pub fn get_bounty_count(env: Env) -> u64 {
-        storage::get_bounty_count(&env)
     }
 }

--- a/src/contract/queries.rs
+++ b/src/contract/queries.rs
@@ -1,0 +1,14 @@
+#[contractimpl]
+impl MergeMintContract {
+    pub fn get_bounty(env: Env, bounty_id: BytesN<32>) -> Option<Bounty> {
+        storage::get_bounty(&env, &bounty_id)
+    }
+
+    pub fn get_contributor(env: Env, address: Address) -> Option<Contributor> {
+        storage::get_contributor(&env, &address)
+    }
+
+    pub fn get_bounty_count(env: Env) -> u64 {
+        storage::get_bounty_count(&env)
+    }
+}


### PR DESCRIPTION
Splits the monolithic `src/contract.rs` into a directory-based module with separate files for queries and mutations, making the separation of concerns explicit.

## Changes
- `src/contract/mod.rs`: contract struct definition, helper functions, constants, and re-exports
- `src/contract/mutations.rs`: state-changing functions (`create_bounty`, `claim_bounty`, `complete_bounty`)
- `src/contract/queries.rs`: read-only functions (`get_bounty`, `get_contributor`, `get_bounty_count`)

All existing tests pass.

Closes #309
Closes #303
Closes #307
Closes #308