### PR TITLE
tooling/maintenance: add devcontainer, VS Code settings, smoke test, and GitHub templates

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "name": "MergeMint Contracts",
+  "image": "mcr.microsoft.com/devcontainers/rust:latest",
+  "postCreateCommand": "rustup target add wasm32-unknown-unknown && cargo install stellar-cli --locked",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "tamasfe.even-better-toml"
+      ],
+      "settings": {
+        "rust-analyzer.cargo.target": "wasm32-unknown-unknown",
+        "editor.formatOnSave": true,
+        "[rust]": {
+          "editor.defaultFormatter": "rust-lang.rust-analyzer"
+        }
+      }
+    }
+  },
+  "forwardPorts": []
+}

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report
+about: Report a bug in the MergeMint contracts
+title: "fix: "
+labels: bug
+assignees: ''
+---
+
+## Bug Description
+
+<!-- A clear and concise description of the bug. -->
+
+## Steps to Reproduce
+
+1. 
+2. 
+3. 
+
+## Expected Behaviour
+
+<!-- What you expected to happen. -->
+
+## Actual Behaviour
+
+<!-- What actually happened. Include any error messages or transaction output. -->
+
+## Environment
+
+- Rust version (`rustc --version`):
+- soroban-sdk version (from `Cargo.toml`):
+- stellar-cli version (`stellar --version`):
+- Network (testnet / mainnet / local):
+- OS:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Propose a new feature or improvement
+title: "feat: "
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+
+<!-- What problem does this feature solve? Why is it needed? -->
+
+## Proposed Solution
+
+<!-- Describe the solution you'd like to see implemented. -->
+
+## Acceptance Criteria
+
+- [ ] 
+- [ ] 
+- [ ] 
+
+## Alternatives Considered
+
+<!-- What other approaches did you consider and why did you rule them out? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary of Changes
+
+<!-- Describe what this PR changes and why. -->
+
+## Related Issue
+
+Closes #
+
+## How to Test
+
+<!-- Steps to verify this change works correctly. -->
+
+1. 
+2. 
+
+## Screenshots / Output
+
+<!-- Paste relevant command output, test results, or screenshots. -->
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] `cargo clippy` passes with no warnings
+- [ ] `cargo fmt` applied
+- [ ] PR description includes `Closes #<issue_id>`

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "rust-lang.rust-analyzer",
+    "tamasfe.even-better-toml",
+    "serayuzgur.crates"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "rust-analyzer.cargo.target": "wasm32-unknown-unknown",
+  "editor.formatOnSave": true,
+  "[rust]": {
+    "editor.defaultFormatter": "rust-lang.rust-analyzer"
+  }
+}

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# End-to-end smoke test: build → deploy → create_bounty → claim_bounty → complete_bounty
+# Required env vars:
+#   ACCOUNT  - funded testnet account (e.g. GXXXXXXX...)
+#   NETWORK  - network passphrase alias (default: testnet)
+
+set -euo pipefail
+
+NETWORK="${NETWORK:-testnet}"
+
+if [[ -z "${ACCOUNT:-}" ]]; then
+  echo "ERROR: ACCOUNT environment variable is required (a funded testnet account public key)." >&2
+  exit 1
+fi
+
+echo "==> [1/5] Building WASM..."
+cargo build --target wasm32-unknown-unknown --release
+WASM_FILE=$(find target/wasm32-unknown-unknown/release -name "*.wasm" | head -1)
+if [[ -z "$WASM_FILE" ]]; then
+  echo "ERROR: No WASM artifact found after build." >&2
+  exit 1
+fi
+echo "    Built: $WASM_FILE"
+
+echo "==> [2/5] Deploying contract to $NETWORK..."
+CONTRACT_ID=$(stellar contract deploy \
+  --wasm "$WASM_FILE" \
+  --source "$ACCOUNT" \
+  --network "$NETWORK" 2>&1 | tail -1)
+if [[ -z "$CONTRACT_ID" ]]; then
+  echo "ERROR: Contract deployment failed." >&2
+  exit 1
+fi
+echo "    Contract ID: $CONTRACT_ID"
+
+echo "==> [3/5] Creating bounty..."
+BOUNTY_ID=$(stellar contract invoke \
+  --id "$CONTRACT_ID" \
+  --source "$ACCOUNT" \
+  --network "$NETWORK" \
+  -- create_bounty \
+  --creator "$ACCOUNT" \
+  --title "Smoke Test Bounty" \
+  --description "Automated smoke test" \
+  --reward 100 \
+  --deadline 9999999999 2>&1 | tail -1)
+if [[ -z "$BOUNTY_ID" ]]; then
+  echo "ERROR: create_bounty did not return an ID." >&2
+  exit 1
+fi
+echo "    Bounty ID: $BOUNTY_ID"
+
+echo "==> [4/5] Claiming bounty..."
+CLAIM_STATUS=$(stellar contract invoke \
+  --id "$CONTRACT_ID" \
+  --source "$ACCOUNT" \
+  --network "$NETWORK" \
+  -- claim_bounty \
+  --bounty_id "$BOUNTY_ID" \
+  --claimant "$ACCOUNT" 2>&1 | tail -1)
+echo "    Claim status: $CLAIM_STATUS"
+
+echo "==> [5/5] Completing bounty..."
+COMPLETE_RESULT=$(stellar contract invoke \
+  --id "$CONTRACT_ID" \
+  --source "$ACCOUNT" \
+  --network "$NETWORK" \
+  -- complete_bounty \
+  --bounty_id "$BOUNTY_ID" \
+  --creator "$ACCOUNT" 2>&1 | tail -1)
+echo "    Complete result: $COMPLETE_RESULT"
+
+echo ""
+echo "Smoke test passed successfully."


### PR DESCRIPTION
## Summary of Changes

- **#291** — Added `.devcontainer/devcontainer.json` using `mcr.microsoft.com/devcontainers/rust:latest` with post-create command to install the WASM target and `stellar-cli`, plus VS Code extensions (`rust-analyzer`, `even-better-toml`) for one-click Codespaces/Dev Container setup.
- **#292** — Added `scripts/smoke_test.sh`: a runnable end-to-end smoke test that builds the WASM, deploys to testnet, then invokes `create_bounty` → `claim_bounty` → `complete_bounty`, printing progress and exiting non-zero on any failure. Requires `ACCOUNT` and optionally `NETWORK` env vars.
- **#293** — Added `.vscode/extensions.json` recommending `rust-analyzer`, `even-better-toml`, and `crates`, and `.vscode/settings.json` setting `rust-analyzer.cargo.target` to `wasm32-unknown-unknown`, `editor.formatOnSave`, and the default Rust formatter.
- **#294** — Added `.github/ISSUE_TEMPLATE/bug_report.md`, `.github/ISSUE_TEMPLATE/feature_request.md`, and `.github/pull_request_template.md` to standardise contributions.

## Related Issues

Closes #291
Closes #292
Closes #293
Closes #294

## How to Test

- Open the repo in GitHub Codespaces — environment should be fully configured after post-create command completes.
- Run `./scripts/smoke_test.sh` with a funded testnet account: `ACCOUNT=G... NETWORK=testnet ./scripts/smoke_test.sh`
- Open in VS Code and confirm rust-analyzer initialises with the WASM target.
- Open a new issue or PR on GitHub and verify the templates are pre-populated.

## Checklist

- [x] `cargo clippy` unaffected (no Rust source changes)
- [x] `cargo fmt` unaffected (no Rust source changes)
- [x] PR description includes `Closes #<issue_id>` for all four issues