### PR TITLE
maintenance: add CHANGELOG, migration docs, Dependabot config, and snapshot audit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    reviewers:
+      - hman38705
+    assignees:
+      - hman38705
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to MergeMint Contracts are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+Changes that have landed on `main` but are not yet associated with a tagged release.
+
+---
+
+## [0.1.0] — 2024-01-01
+
+### Added
+
+- `create_bounty` — creates a new bounty with reward token, amount, and optional deadline.
+- `claim_bounty` — allows a contributor to claim an open bounty (enforces min reputation and deadline).
+- `complete_bounty` — distributes reward to assignees proportionally by basis-point share.
+- `cancel_bounty` — cancels an open or in-progress bounty and refunds the creator.
+- `raise_dispute` — transitions a bounty into the `disputed` state.
+- `update_contributor_metadata` — lets a contributor update their off-chain profile URI.
+- `get_bounty` / `get_contributor` — read-only accessors for off-chain consumers.
+- `Bounty` struct with fields: `creator`, `reward_amount`, `reward_token`, `assignees`, `max_assignees`, `status`, `min_reputation`, `deadline`.
+- `Contributor` struct with fields: `address`, `reputation`, `total_earned`, `contribution_count`, `active_claims`, `metadata`.
+- `DataKey` enum covering `BountyCount`, `Bounty`, `BountyMeta`, `Contributor`, `StatusIndex`, `OpenBounties`.
+- Status index tracking bounty lifecycle transitions via `StatusIndex(Symbol)`.
+- Open bounties index via `OpenBounties` persistent storage key.
+- Multi-assignee support with configurable `max_assignees` and basis-point share splitting.
+
+---
+
+[Unreleased]: https://github.com/mergemint-mint/mergemint-contracts/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/mergemint-mint/mergemint-contracts/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,11 +16,50 @@ cargo test
 
 All tests must pass before submitting a PR.
 
+## Changelog
+
+Every pull request that changes the contract interface **must** include a `CHANGELOG.md` entry under the `[Unreleased]` section. The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+A "contract interface change" includes:
+- Adding, removing, or renaming a public contract function
+- Changing the parameters or return type of a public function
+- Adding, removing, or reordering fields in `Bounty`, `Contributor`, `BountyMeta`, or `DataKey`
+- Changing the set of events emitted by any function
+
+Use the appropriate subsection (`Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`) inside `[Unreleased]`. Example:
+
+```markdown
+## [Unreleased]
+
+### Added
+- `update_contributor_metadata` — lets contributors update their off-chain profile URI.
+
+### Changed
+- `Bounty` — added optional `deadline` field (ledger sequence number).
+```
+
+PRs that touch only tests, documentation, CI, or tooling do not require a changelog entry, but one is welcome.
+
 ## Test Snapshots
 
 ### What Are Snapshots?
 
 Test snapshots in `test_snapshots/` capture the Soroban ledger state after contract operations. They verify that storage, type encodings, and struct layouts remain consistent across code changes.
+
+The current snapshots and the structs they cover:
+
+| Snapshot file | Primary struct tested |
+|---|---|
+| `test_bounty_count.1.json` | `DataKey::BountyCount` |
+| `test_claim_bounty.1.json` | `Bounty`, `Contributor` |
+| `test_complete_bounty_updates_status.1.json` | `Bounty` status transitions |
+| `test_contributor_reputation.1.json` | `Contributor` |
+| `test_create_bounty.1.json` | `Bounty`, `DataKey` |
+| `test_status_index_tracks_bounty_lifecycle.1.json` | `DataKey::StatusIndex` |
+
+### How Snapshots Are Generated
+
+Soroban's test infrastructure writes snapshot files automatically when a test that uses `Env::default()` completes. Running `cargo test` with a clean `test_snapshots/` directory will regenerate all files. On subsequent runs the framework compares the live ledger state against the stored JSON; a mismatch fails the test.
 
 ### When Snapshots Become Stale
 
@@ -29,26 +68,35 @@ Snapshots must be regenerated if:
 - A field is removed or reordered
 - A field type changes (e.g., `u32` → `u64`)
 - Field visibility or attributes change
+- A new `DataKey` variant is added
 
 ### Regenerating Snapshots
 
-If a test fails with a snapshot mismatch, regenerate with:
+Delete the existing snapshots and rerun the test suite:
 
 ```bash
-cargo test -- --nocapture
+rm -f test_snapshots/test/*.json
+cargo test
 ```
 
-Then review the diff and commit the updated snapshots.
+The test run will recreate all snapshot files from the current ledger state. Review the new JSON files with `git diff` before committing to confirm the changes are intentional.
+
+If you only want to regenerate a single snapshot, delete that file and run the specific test:
+
+```bash
+rm test_snapshots/test/test_create_bounty.1.json
+cargo test test_create_bounty
+```
 
 ### Verifying Snapshots
 
-To ensure all snapshots are valid:
+To ensure all snapshots are current and pass:
 
 ```bash
 cargo test
 ```
 
-If tests pass, snapshots are current.
+If all tests pass without modification, the snapshots are valid against the current schema.
 
 ## Code Style
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,170 @@
+# Storage Migration Strategy
+
+Soroban persistent storage serialises `#[contracttype]` structs to XDR at compile time. Any change to a struct's field layout — adding, removing, or reordering fields — will cause existing ledger entries to fail deserialisation. `get_bounty` and `get_contributor` will panic rather than return stale data.
+
+This document describes the available migration strategies and the recommended approach for MergeMint.
+
+---
+
+## Why schema changes break storage
+
+The `#[contracttype]` macro generates XDR encoding derived from the field declaration order. Existing ledger entries encoded against `BountyV1` cannot be decoded with `BountyV2` if their XDR layouts differ. There is no automatic schema evolution in Soroban.
+
+---
+
+## Option 1 — Versioned structs (recommended)
+
+Introduce a new struct for each breaking schema version and store an enum that wraps all versions under a single `DataKey`.
+
+```rust
+#[contracttype]
+pub struct BountyV1 {
+    pub creator: Address,
+    pub reward_amount: i128,
+    // ... original fields
+}
+
+#[contracttype]
+pub struct BountyV2 {
+    pub creator: Address,
+    pub reward_amount: i128,
+    pub tags: Vec<Symbol>,   // new field
+    // ... other fields
+}
+
+#[contracttype]
+pub enum BountyVersioned {
+    V1(BountyV1),
+    V2(BountyV2),
+}
+```
+
+**On read** — deserialise the enum, match on the variant, and upgrade in place before returning:
+
+```rust
+pub fn get_bounty(env: &Env, id: BytesN<32>) -> Bounty {
+    let versioned: BountyVersioned = env.storage().persistent()
+        .get(&DataKey::Bounty(id.clone()))
+        .unwrap_or_else(|| panic!("bounty not found"));
+
+    match versioned {
+        BountyVersioned::V1(v1) => migrate_v1_to_v2(v1),
+        BountyVersioned::V2(v2) => v2,
+    }
+}
+```
+
+**Trade-offs:**
+- No downtime required; migration is lazy and happens on first access.
+- Ledger entries are never invalidated — old entries coexist with new ones.
+- Read functions grow more complex with each version added.
+- Old variants must be retained in the enum forever (or until a full migration is complete).
+
+---
+
+## Option 2 — Lazy migration on read (write-back pattern)
+
+Similar to versioned structs but the migration is persisted back to storage on every read of an old entry, so old variants are gradually eliminated without a dedicated migration transaction.
+
+```rust
+pub fn get_bounty(env: &Env, id: BytesN<32>) -> BountyV2 {
+    let versioned: BountyVersioned = env.storage().persistent()
+        .get(&DataKey::Bounty(id.clone()))
+        .expect("bounty not found");
+
+    let current = match versioned {
+        BountyVersioned::V1(v1) => {
+            let upgraded = migrate_v1_to_v2(v1);
+            // Write the upgraded entry back so future reads are free.
+            env.storage().persistent()
+                .set(&DataKey::Bounty(id), &BountyVersioned::V2(upgraded.clone()));
+            upgraded
+        }
+        BountyVersioned::V2(v2) => v2,
+    };
+    current
+}
+```
+
+**Trade-offs:**
+- Eliminates old variants over time without a one-shot migration transaction.
+- Every read of a stale entry pays a write fee.
+- The contract must remain authorised to write during normal user operations.
+
+---
+
+## Option 3 — One-time admin migration function
+
+Add an admin-only function that iterates over all bounties and rewrites them under the new schema in a single transaction.
+
+```rust
+pub fn migrate_bounties(env: &Env, admin: Address, ids: Vec<BytesN<32>>) {
+    admin.require_auth();
+    for id in ids.iter() {
+        let old: BountyV1 = env.storage().persistent()
+            .get(&DataKey::Bounty(id.clone()))
+            .expect("bounty not found");
+        let new = migrate_v1_to_v2(old);
+        env.storage().persistent()
+            .set(&DataKey::Bounty(id), &BountyVersioned::V2(new));
+    }
+}
+```
+
+**Trade-offs:**
+- Clean cut-over; no version branching in read paths after migration completes.
+- Migration must be executed before the new contract version goes live.
+- Soroban instruction limits constrain how many entries can be migrated per invocation; large data sets require batched calls.
+- Risk of partial migration if the transaction fails mid-way.
+
+---
+
+## Option 4 — Contract replacement
+
+Deploy a new contract instance, copy state via an export/import mechanism, and redirect integrators to the new address.
+
+**Trade-offs:**
+- Guarantees a clean schema with no legacy code paths.
+- All integrators must update to the new contract address.
+- Requires coordinated deployment across the MergeMint API, TypeScript SDK, and any third-party tools.
+- Most disruptive option; suitable only for major breaking changes that cannot be handled incrementally.
+
+---
+
+## Recommended approach for MergeMint
+
+**Use versioned structs (Option 1) with lazy write-back (Option 2) for incremental changes.**
+
+- Wrap `Bounty` and `Contributor` in `BountyVersioned` / `ContributorVersioned` enums.
+- Perform in-place migration on read; write the upgraded struct back to storage immediately so future reads are free.
+- Reserve the admin migration function (Option 3) for cases where a large number of entries must be upgraded before a deadline (e.g., TTL pressure).
+- Reserve contract replacement (Option 4) for major architectural changes only.
+
+### Versioning policy
+
+| Change type | Strategy |
+|---|---|
+| Add optional field (`Option<T>`) | Versioned struct + lazy write-back |
+| Add required field | Versioned struct + lazy write-back |
+| Remove field | Versioned struct (keep old field in `V_n`, drop in `V_n+1`) |
+| Reorder fields | Versioned struct |
+| Change field type | Versioned struct |
+| Rename `DataKey` variant | Admin migration or contract replacement |
+
+### When to use `Option<T>` instead of a new struct version
+
+If a new field is genuinely optional and `None` is a valid sentinel for "not set on old entries," adding `Option<T>` to the current struct avoids a version bump. Soroban XDR encodes `Option<T>` as a union with a presence flag, so `None` at the end of a struct is backward-compatible **only if** existing entries are regenerated with the `None` variant before the new code is deployed. In practice this means running an admin migration first; otherwise old entries still fail to deserialise.
+
+---
+
+## TTL considerations
+
+Soroban persistent storage entries have a TTL. Migrated entries written back during a lazy read inherit the new TTL from the write call. Ensure that `extend_ttl` calls in `get_bounty` / `get_contributor` are applied to the migrated entry, not the stale one.
+
+---
+
+## Related documents
+
+- [Architecture overview](architecture.md)
+- [Event schema](event-schema.md)
+- [CHANGELOG](../CHANGELOG.md)


### PR DESCRIPTION
## Summary

- **CHANGELOG.md** — new file at repo root following Keep a Changelog format with an `[Unreleased]` section and a documented `[0.1.0]` baseline release (closes #295)
- **docs/migration.md** — new document covering all four storage migration strategies (versioned structs, lazy write-back, one-time admin migration, contract replacement) with trade-off analysis and a recommended approach for MergeMint (closes #296)
- **.github/dependabot.yml** — weekly Cargo dependency update PRs, capped at 5 open PRs, assigned and reviewed by the maintainer (closes #297)
- **CONTRIBUTING.md** — expanded with: (1) changelog requirements for all PRs that touch the contract interface, (2) full snapshot generation/regeneration instructions including per-file coverage table and single-test regeneration command (closes #298)

## Closes

Closes #295
Closes #296
Closes #297
Closes #298

