### PR TITLE
docs: add stellar-cli invocation examples and security threat model

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Built with **Rust (`no_std`)** using the **Soroban SDK 23**, compiled to WASM (`
 - [Events](#events)
 - [Code Highlights](#code-highlights)
 - [Getting Started](#getting-started)
+- [CLI Usage](#cli-usage)
 - [Project Structure](#project-structure)
 - [Testing](#testing)
 - [Deployment](#deployment)
@@ -675,6 +676,176 @@ stellar contract deploy \
 
 echo "Deployment complete!"
 ```
+
+---
+
+## CLI Usage
+
+After deploying the contract, you can invoke each function directly with the **Stellar CLI**. Export these shell variables once to keep the examples concise:
+
+```bash
+export CONTRACT_ID=<your-deployed-contract-id>   # C... contract address
+export CREATOR=<your-stellar-address>             # G... public key or key alias
+export NETWORK=testnet
+```
+
+> **Type encoding quick reference**
+> | Soroban type | CLI encoding |
+> |---|---|
+> | `Address` | Stellar public key (`G...`) or key alias |
+> | `BytesN<32>` | 64-character lowercase hex string |
+> | `Symbol` | Alphanumeric + underscore string (max 32 chars, no spaces) |
+> | `i128` | Integer literal |
+> | `u32` | Integer literal |
+> | `Option<T>` | `null` for `None`; bare value for `Some(value)` |
+
+---
+
+### create_bounty
+
+Creates a new open bounty and returns the generated 32-byte bounty ID as a hex string. The `reward_amount` is in raw token units — for a token with 7 decimal places, 1 token = `10000000`. Set `min_reputation` to `0` to allow any contributor to claim, and pass `null` for `deadline` to leave the bounty open indefinitely.
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source $CREATOR \
+  --network $NETWORK \
+  -- create_bounty \
+  --creator $CREATOR \
+  --title "Fix_auth_timeout" \
+  --description "Resolve_session_expiry_in_login_flow" \
+  --reward_amount 10000000 \
+  --reward_token GBDTYLEFTNKBV6DCLAURRRXN6VWQPGSZYDVS9GVQWGYLXNUDGQE2HSTW \
+  --min_reputation 0 \
+  --deadline null
+```
+
+Example return value:
+
+```
+"0000000000000000000000000000000000000000000000000000000000000000"
+```
+
+> Bounty IDs are 32-byte big-endian encodings of an incrementing counter — bounty #0 is all zeros, bounty #1 ends in `...0001`, and so on. Copy the exact hex string returned here for use in `claim_bounty`, `complete_bounty`, and `get_bounty`.
+
+---
+
+### claim_bounty
+
+Assigns the calling contributor to an open bounty. The contributor must authenticate with `--source`. A contributor can only hold one active claim at a time.
+
+```bash
+export CONTRIBUTOR=GBCONTRIBUTORAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+export BOUNTY_ID=0000000000000000000000000000000000000000000000000000000000000000
+
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source $CONTRIBUTOR \
+  --network $NETWORK \
+  -- claim_bounty \
+  --contributor $CONTRIBUTOR \
+  --bounty_id $BOUNTY_ID
+```
+
+The command returns no value on success. It will panic if:
+- The bounty is already at assignee capacity
+- The contributor already has an active claim
+- The bounty deadline has passed
+
+---
+
+### complete_bounty
+
+Marks the bounty completed and transfers the reward from the verifier's wallet to the assignee(s). The verifier must hold at least `reward_amount` of the bounty's `reward_token` and must sign the transaction with `--source`.
+
+```bash
+export VERIFIER=GBVERIFIERAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+export BOUNTY_ID=0000000000000000000000000000000000000000000000000000000000000000
+
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source $VERIFIER \
+  --network $NETWORK \
+  -- complete_bounty \
+  --verifier $VERIFIER \
+  --bounty_id $BOUNTY_ID
+```
+
+On success the reward is transferred on-chain, the assignee's reputation increases by +10, and `bounty_completed` / `reward_paid` events are emitted.
+
+---
+
+### get_bounty
+
+Returns the full `Bounty` struct for a given ID, or `null` if the ID does not exist. Read-only — no state changes occur.
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source $CREATOR \
+  --network $NETWORK \
+  -- get_bounty \
+  --bounty_id 0000000000000000000000000000000000000000000000000000000000000000
+```
+
+Example output:
+
+```json
+{
+  "creator": "GABC...",
+  "reward_amount": "10000000",
+  "reward_token": "GBDT...",
+  "assignees": [],
+  "max_assignees": 1,
+  "status": "open",
+  "min_reputation": 0,
+  "deadline": null
+}
+```
+
+---
+
+### get_contributor
+
+Returns the `Contributor` profile for a wallet address, or `null` if the address has no recorded activity. Read-only — no state changes occur.
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source $CREATOR \
+  --network $NETWORK \
+  -- get_contributor \
+  --address GBCONTRIBUTORAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+```
+
+Example output:
+
+```json
+{
+  "address": "GBCO...",
+  "reputation": 10,
+  "total_earned": "10000000",
+  "contribution_count": 1,
+  "active_claims": 0,
+  "metadata": null
+}
+```
+
+---
+
+### get_bounty_count
+
+Returns the total number of bounties ever created (not the number currently open). Read-only — no state changes occur.
+
+```bash
+stellar contract invoke \
+  --id $CONTRACT_ID \
+  --source $CREATOR \
+  --network $NETWORK \
+  -- get_bounty_count
+```
+
+Example output: `1`
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,38 +1,172 @@
-# Security Model
+# Security Threat Model
 
-## Current model (no escrow)
+This document analyses known attack vectors against the MergeMint contract, rates their severity, describes current mitigations, and identifies residual risk. It covers the **current no-escrow design** (the contract never holds a token balance; the verifier pushes tokens directly from their own wallet) as well as the **planned escrow model** where the contract will custody funds.
 
-In the current design the verifier holds tokens off-chain and calls `complete_bounty` to push
-them to the assignee via `token.transfer`. The contract itself never holds a token balance.
-The attack surface is limited to:
+---
 
-- **Authentication bypass** — every state-changing function calls `require_auth()` on the
-  relevant actor (creator, contributor, or verifier).
-- **Double-assignment** — `claim_bounty` panics if `assignee` is already `Some`.
-- **Monotonic reputation** — reputation only ever increases; no underflow path exists.
+## Severity scale
+
+| Rating | Meaning |
+|--------|---------|
+| **Critical** | Direct, unconditional fund loss or unauthorised privilege escalation |
+| **High** | Likely fund loss or state corruption under realistic conditions |
+| **Medium** | Requires unusual preconditions or yields only partial impact |
+| **Low** | Negligible financial impact; primarily affects data integrity |
+
+---
+
+## Current model (no-escrow) threat vectors
+
+### 1. Verifier collusion
+
+**Severity:** High
+
+**Description:** The verifier role is unconstrained by the contract — any address that calls `complete_bounty` and has a sufficient token balance can pay a reward. A verifier and a bounty creator (or a verifier acting alone) can therefore collude: they designate a fake contributor as assignee via `claim_bounty`, then the verifier calls `complete_bounty` to transfer tokens to that address and award +10 reputation — all without any genuine work having been done. Because the contract has no on-chain way to verify off-chain contribution quality, this is a social-trust attack rather than a code flaw.
+
+**Affected functions:** `claim_bounty`, `complete_bounty`
+
+**Current mitigations:**
+- All parties must individually authenticate with `require_auth()`, so no single actor can execute the attack alone — at least two colluding parties are required (verifier + contributor, or creator + contributor with creator also acting as verifier).
+- Events (`bounty_claimed`, `bounty_completed`, `reward_paid`) are emitted on-chain and consumed by the MergeMint API indexer, giving off-chain observers an audit trail.
+
+**Residual risk:** High. Collusion cannot be detected or prevented purely on-chain. Off-chain reputation systems, dispute resolution, and community governance are the necessary backstop. See also threat vector #3 (self-verify) for the degenerate single-actor case.
+
+---
+
+### 2. Front-running of `claim_bounty`
+
+**Severity:** Medium
+
+**Description:** On Stellar, multiple transactions can land in the same ledger. If a legitimate contributor broadcasts `claim_bounty` and a malicious observer monitors the network and submits a competing `claim_bounty` for the same bounty with a higher fee, the malicious transaction may be ordered first within that ledger. The attacker claims the bounty slot before the legitimate contributor.
+
+**Affected functions:** `claim_bounty`
+
+**Current mitigations:**
+- The double-assignment guard (`assignees.len() >= max_assignees`) ensures only one claim succeeds for a single-assignee bounty — the second transaction will panic cleanly with `BOUNTY_ALREADY_ASSIGNED`, preventing silent data corruption.
+- Stellar's ledger ordering is not purely fee-based and is harder to predict than Ethereum's mempool, reducing reliable front-running opportunity.
+
+**Residual risk:** Medium. A well-resourced attacker with low-latency network access can still outrun a legitimate claim. The protocol does not whitelist specific contributors per bounty. Integrators who need claim exclusivity should add an off-chain reservation layer or implement allowlist logic before calling `claim_bounty`.
+
+---
+
+### 3. Self-claim (creator claiming their own bounty)
+
+**Severity:** Medium
+
+**Description:** There is no on-chain check preventing a bounty creator from also being the contributor who calls `claim_bounty`. A creator could therefore post a bounty, claim it themselves, then coordinate with a verifier to `complete_bounty` — earning the reward back plus +10 reputation for no external work. The error constant `CREATOR_CANNOT_CLAIM` exists in `src/errors.rs` but is **not enforced** anywhere in `contract.rs`.
+
+**Affected functions:** `claim_bounty`
+
+**Current mitigations:** None enforced on-chain.
+
+**Residual risk:** High. This is an unmitigated on-chain vulnerability. The fix is a single guard at the top of `claim_bounty`:
+
+```rust
+if contributor == bounty.creator {
+    panic!("{}", errors::CREATOR_CANNOT_CLAIM);
+}
+```
+
+Until this guard is added, off-chain tooling (MergeMint API, front-end) must reject self-claims as a compensating control.
+
+---
+
+### 4. Self-verify (verifier is also an assignee)
+
+**Severity:** High
+
+**Description:** There is no on-chain check preventing the verifier who calls `complete_bounty` from also being one of the bounty's assignees. In this scenario the verifier calls `token.transfer(&verifier, &assignee, &payout)` where both sides resolve to their own address — a net-zero token movement — but they still receive +10 reputation and an increment to `contribution_count` and `total_earned`. The error constant `VERIFIER_CANNOT_BE_ASSIGNEE` exists in `src/errors.rs` but is **not enforced** in `contract.rs`.
+
+**Affected functions:** `complete_bounty`
+
+**Current mitigations:** None enforced on-chain.
+
+**Residual risk:** High. An actor who controls both the verifier key and claims a bounty can manufacture unlimited reputation at zero cost. The fix is a guard inside the assignee loop of `complete_bounty`:
+
+```rust
+for (assignee, share_bp) in bounty.assignees.iter() {
+    if assignee == verifier {
+        panic!("{}", errors::VERIFIER_CANNOT_BE_ASSIGNEE);
+    }
+    ...
+}
+```
+
+---
+
+### 5. Double-completion (reward drain via repeated `complete_bounty`)
+
+**Severity:** High
+
+**Description:** `complete_bounty` does not validate that `bounty.status == STATUS_IN_PROGRESS` before executing. After the first successful call the status is written as `STATUS_COMPLETED` and stored, but the `assignees` list remains populated. A second call by the same verifier therefore passes the `assignees.is_empty()` guard, executes another `token.transfer` for each assignee, and increments every assignee's `reputation`, `total_earned`, and `contribution_count` again. This can be repeated as many times as the verifier has tokens, draining the verifier's balance and inflating contributor reputation scores.
+
+**Affected functions:** `complete_bounty`
+
+**Current mitigations:**
+- The verifier must authenticate and must hold sufficient token balance for each repeat call, so exploiting this requires a co-operating or compromised verifier.
+- The `status` field is correctly updated to `STATUS_COMPLETED` after the first call, so off-chain tooling can detect the anomaly.
+
+**Residual risk:** High. The fix is a status guard at the entry of `complete_bounty` (referenced in the escrow checklist below):
+
+```rust
+if bounty.status != Symbol::new(&env, STATUS_IN_PROGRESS) {
+    panic!("{}", errors::BOUNTY_NOT_IN_PROGRESS);
+}
+```
+
+This guard blocks all repeat calls regardless of who the verifier is.
+
+---
+
+### 6. Reentrancy via token transfer
+
+**Severity:** Low (current model), High (escrow model)
+
+**Description:** `complete_bounty` calls `token.transfer` before updating `bounty.status` to `STATUS_COMPLETED` and persisting the change. In the EVM this ordering would be a critical reentrancy bug. On Soroban, the runtime enforces single-contract-at-a-time execution — a token contract cannot call back into `MergeMintContract` during the same invocation — eliminating classic reentrancy in the current design.
+
+However, when the escrow model is introduced (the contract holds token balances), this ordering will become critical. Any escape to an external contract before the status is written creates a reentrancy window on future Soroban versions or cross-contract paths that may be introduced.
+
+**Affected functions:** `complete_bounty`
+
+**Current mitigations:**
+- Soroban's single-contract execution model prevents reentrancy in the current runtime.
+
+**Residual risk:** Low now, Critical under escrow. Enforce checks-effects-interactions proactively: write `bounty.status = STATUS_COMPLETED` and call `storage::store_bounty` *before* any `token.transfer` call. This also eliminates the double-completion vulnerability (#5) as a side effect.
+
+---
+
+### 7. Reputation inflation via multi-claim griefing
+
+**Severity:** Low
+
+**Description:** An actor with control over both a verifier key and multiple contributor keys can create many low-value bounties, claim each with a different contributor key, then call `complete_bounty` for each. Each completion awards +10 reputation and +1 `contribution_count`. Because `reward_amount` can be arbitrarily small (no minimum is enforced), the economic cost per reputation point approaches zero.
+
+**Affected functions:** `create_bounty`, `complete_bounty`
+
+**Current mitigations:**
+- Each `claim_bounty` call requires a unique contributor address (duplicate-address guard is enforced).
+- The `active_claims` limit (currently 1 per contributor) prevents a single address from gaming the count without completing prior bounties.
+- Transaction fees on Stellar impose a small but non-zero cost per operation.
+
+**Residual risk:** Medium. An attacker with many keys can still inflate reputation cheaply. Mitigations include enforcing a minimum `reward_amount` in `create_bounty` and adding a `CONTRIBUTOR_HAS_ACTIVE_CLAIM` style cap on total lifetime completions per verifier.
 
 ---
 
 ## Escrow threat model
 
-When escrow is introduced the contract will hold tokens on behalf of bounty creators
-(`create_bounty` transfers reward tokens *into* the contract; `complete_bounty` and
-`cancel_bounty` transfer them *out*). This changes the threat surface significantly.
+When escrow is introduced the contract will hold tokens on behalf of bounty creators (`create_bounty` transfers reward tokens *into* the contract; `complete_bounty` and `cancel_bounty` transfer them *out*). This changes the threat surface significantly.
 
 ### Token balance invariant
 
-> **The contract's token balance for any given token must always equal the sum of
-> `reward_amount` across all bounties in `open` or `in_progress` status that use that token.**
+> **The contract's token balance for any given token must always equal the sum of `reward_amount` across all bounties in `open` or `in_progress` status that use that token.**
 
-Maintaining this invariant is the primary correctness goal for all escrow-related code paths.
-Any deviation — even transient — represents a fund safety bug.
+Maintaining this invariant is the primary correctness goal for all escrow-related code paths. Any deviation — even transient — represents a fund safety bug.
 
 ### Attack vectors
 
-#### 1. Stuck funds (locked tokens)
+#### Stuck funds (locked tokens)
 
-**Description:** A bug prevents a bounty from ever reaching `completed` or `cancelled`, locking
-the escrowed tokens permanently.
+**Description:** A bug prevents a bounty from ever reaching `completed` or `cancelled`, locking the escrowed tokens permanently.
 
 **Example scenarios:**
 - `cancel_bounty` panics unconditionally due to a logic error.
@@ -40,49 +174,27 @@ the escrowed tokens permanently.
 - A missing code path for a status transition leaves a bounty stuck.
 
 **Mitigations:**
-- Ensure `cancel_bounty` is callable by the creator for any bounty in `open` or `in_progress`
-  status — it must always provide an exit.
+- Ensure `cancel_bounty` is callable by the creator for any bounty in `open` or `in_progress` status — it must always provide an exit.
 - Consider a verifier-only emergency cancel path as a backstop.
-- Write invariant-checking tests that verify the contract balance equals the sum of open
-  bounty rewards after every state transition.
+- Write invariant-checking tests that verify the contract balance equals the sum of open bounty rewards after every state transition.
 
-#### 2. Fund drain (double-completion or reentrancy)
+#### Fund drain (double-completion or reentrancy)
 
-**Description:** An attacker triggers multiple payouts for a single bounty, draining more tokens
-than the bounty's `reward_amount`.
-
-**Example scenarios:**
-- `complete_bounty` is called twice before the status is persisted as `completed`, paying the
-  reward twice (a classic check-effects-interactions violation).
-- Reentrancy via a malicious token contract that calls back into `complete_bounty` during
-  `token.transfer`.
+**Description:** An attacker triggers multiple payouts for a single bounty, draining more tokens than the bounty's `reward_amount`.
 
 **Mitigations:**
-- Follow checks-effects-interactions strictly: update the bounty status to `completed` and
-  persist it *before* calling `token.transfer`.
-- Validate that `bounty.status == STATUS_IN_PROGRESS` at the top of `complete_bounty` and
-  panic otherwise — this prevents double-completion even without reentrancy guards.
-- Note: Soroban's single-contract-at-a-time execution model eliminates classic reentrancy, but
-  the ordering discipline should still be enforced for clarity and defence-in-depth.
+- Enforce checks-effects-interactions strictly: update the bounty status to `completed` and persist it *before* calling `token.transfer`.
+- Validate that `bounty.status == STATUS_IN_PROGRESS` at the top of `complete_bounty` — this prevents double-completion even without reentrancy guards. This is also the fix for threat #5 in the current model.
 
-#### 3. Griefing (gas/fee exhaustion)
+#### Griefing (ledger pollution)
 
-**Description:** A malicious actor creates many bounties (locking the minimum viable reward in
-each) and immediately cancels them, burning transaction fees and polluting the status index.
-
-**Example scenarios:**
-- Rapid create → cancel cycles pad the `cancelled` index, increasing read costs for
-  `get_bounties_by_status("cancelled")`.
-- Large numbers of `open` bounties with tiny rewards deter legitimate contributors.
+**Description:** A malicious actor creates many bounties (locking the minimum viable reward in each) and immediately cancels them, burning transaction fees and polluting the status index.
 
 **Mitigations:**
 - Enforce a minimum `reward_amount` in `create_bounty` to raise the economic cost of griefing.
-- Consider a creation fee (paid to the contract or burned) that is separate from the bounty
-  reward, making spam attacks self-limiting.
-- The status index is unbounded today; if griefing is a concern, cap index length or paginate
-  reads.
+- Consider a creation fee (paid to the contract or burned) that is separate from the bounty reward.
 
-### High-risk code paths
+### High-risk code paths (escrow)
 
 | Function          | Risk                                      | Key invariant to enforce                              |
 |-------------------|-------------------------------------------|-------------------------------------------------------|
@@ -90,11 +202,14 @@ each) and immediately cancels them, burning transaction fees and polluting the s
 | `complete_bounty` | Token transfer out; double-payment        | Status set to `completed` before `token.transfer`     |
 | `cancel_bounty`   | Token transfer out; stuck-fund if blocked | Always reachable by creator; status set before transfer |
 
-### Recommended pre-merge checklist for escrow
+### Pre-merge checklist for escrow
 
+- [ ] Add status guard to `complete_bounty`: panic if `status != in_progress`.
+- [ ] Enforce `reward_amount > 0` in `create_bounty`.
+- [ ] Add creator-cannot-claim guard in `claim_bounty` (fixes threat #3).
+- [ ] Add verifier-cannot-be-assignee guard in `complete_bounty` (fixes threat #4).
 - [ ] Fuzz `reward_amount` edge cases (0, `i128::MAX`, negative).
-- [ ] Add an integration test that asserts `contract_balance == sum(open + in_progress rewards)`
-      after each transition.
+- [ ] Add integration test: `contract_balance == sum(open + in_progress rewards)` after every state transition.
 - [ ] Confirm `complete_bounty` panics when called on an already-completed bounty.
 - [ ] Review token contract for any re-entrant callbacks into this contract.
 - [ ] Have at least one contributor who was not the author review the token transfer ordering.


### PR DESCRIPTION
## Summary

- Adds a **CLI Usage** section to `README.md` with `stellar contract invoke` examples for all six contract functions (`create_bounty`, `claim_bounty`, `complete_bounty`, `get_bounty`, `get_contributor`, `get_bounty_count`), including a type-encoding reference table for `BytesN<32>`, `Address`, `Symbol`, `i128`, and `Option<T>`
- Rewrites `docs/security.md` as a formal threat model with severity ratings, per-threat mitigations, and residual risk analysis covering verifier collusion, front-running, self-claim, self-verify, double-completion, reentrancy, and reputation inflation
- Flags two unenforced error constants (`CREATOR_CANNOT_CLAIM`, `VERIFIER_CANNOT_BE_ASSIGNEE`) and the missing status guard in `complete_bounty` as concrete action items for follow-uphttps://github.com/mergemint-mint/mergemint-contracts/pull/392

Closes #386
Closes #387

## Test plan

- [ ] Verify CLI examples render correctly in GitHub markdown
- [ ] Confirm `create_bounty` example uses current signature (`min_reputation`, `deadline` params added in #385)
- [ ] Confirm `docs/security.md` threat numbering and cross-references are consistent
- [ ] Spot-check one example against a testnet deployment to confirm flag names match the compiled ABI

closes #279 
closes #280 
closes #281 
closes #282 