### PR TITLE
feat: implement #266 #269 #270 #275

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 target/
+**/*.rs.bk
+Cargo.lock
+.env
+*.wasm

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,9 +1,10 @@
+// SPDX-License-Identifier: MIT
 use soroban_sdk::{contract, contractimpl, token::TokenClient, Address, BytesN, Env, Symbol, Vec};
 
 use crate::errors;
 use crate::events;
 use crate::storage;
-use crate::types::{Bounty, BountyMeta, Contributor};
+use crate::types::{Bounty, BountyMeta, Contributor, Milestone};
 
 const STATUS_OPEN: &str = "open";
 const STATUS_IN_PROGRESS: &str = "in_progress";
@@ -13,8 +14,7 @@ const STATUS_DISPUTED: &str = "disputed";
 
 fn generate_bounty_id(env: &Env, count: u64) -> BytesN<32> {
     let mut buf = [0u8; 32];
-    let count_bytes = count.to_be_bytes();
-    buf[24..32].copy_from_slice(&count_bytes);
+    buf[24..32].copy_from_slice(&count.to_be_bytes());
     BytesN::from_array(env, &buf)
 }
 
@@ -32,6 +32,7 @@ impl MergeMintContract {
         reward_token: Address,
         min_reputation: u32,
         deadline: Option<u32>,
+        milestones: Option<Vec<Milestone>>,
     ) -> BytesN<32> {
         creator.require_auth();
 
@@ -47,6 +48,7 @@ impl MergeMintContract {
             status: Symbol::new(&env, STATUS_OPEN),
             min_reputation,
             deadline,
+            milestones,
         };
 
         let meta = BountyMeta { title, description };
@@ -64,10 +66,6 @@ impl MergeMintContract {
         id
     }
 
-    /// Claim an open bounty. A contributor receives 10 000 basis points (full reward)
-    /// when claiming a single-assignee bounty (`max_assignees == 1`).
-    /// For multi-assignee bounties the caller must supply an explicit `share` in basis
-    /// points; the sum of all shares must not exceed 10 000.
     pub fn claim_bounty(env: Env, contributor: Address, bounty_id: BytesN<32>) {
         contributor.require_auth();
 
@@ -76,56 +74,38 @@ impl MergeMintContract {
             None => panic!("{}", errors::BOUNTY_NOT_FOUND),
         };
 
-        // Reject if already at capacity.
         if bounty.assignees.len() >= bounty.max_assignees {
             panic!("{}", errors::BOUNTY_ALREADY_ASSIGNED);
         }
 
-        // Reject if the contributor is already listed.
         for (addr, _) in bounty.assignees.iter() {
             if addr == contributor {
                 panic!("{}", errors::BOUNTY_ALREADY_ASSIGNED);
             }
         }
 
+        // #275: use Contributor::new for default construction
         let mut contrib = storage::get_contributor(&env, &contributor)
-            .unwrap_or(Contributor {
-                address: contributor.clone(),
-                reputation: 0,
-                total_earned: 0,
-                contribution_count: 0,
-                active_claims: 0,
-                metadata: None,
-            });
+            .unwrap_or_else(|| Contributor::new(contributor.clone()));
 
         if contrib.active_claims >= 1 {
             panic!("{}", errors::CONTRIBUTOR_HAS_ACTIVE_CLAIM);
         }
 
-        // Deadline enforcement: if a deadline is set and has passed, reject the claim
         if let Some(deadline) = bounty.deadline {
             if env.ledger().sequence() > deadline {
                 panic!("{}", errors::BOUNTY_DEADLINE_PASSED);
             }
         }
 
-        if bounty.min_reputation > 0 {
-            let contributor_profile = storage::get_contributor(&env, &contributor).unwrap_or(Contributor {
-                address: contributor.clone(),
-                reputation: 0,
-                total_earned: 0,
-                contribution_count: 0,
-            });
-            if contributor_profile.reputation < bounty.min_reputation {
-                panic!("contributor reputation is too low");
-            }
+        if bounty.min_reputation > 0 && contrib.reputation < bounty.min_reputation {
+            panic!("contributor reputation is too low");
         }
 
         let previous_status = bounty.status.clone();
-        bounty.assignee = Some(contributor.clone());
+        bounty.assignees.push_back((contributor.clone(), 10_000u32));
         bounty.status = Symbol::new(&env, STATUS_IN_PROGRESS);
 
-        let previous_status = Symbol::new(&env, STATUS_OPEN);
         storage::store_bounty(&env, &bounty_id, &bounty);
         storage::move_bounty_status(&env, &bounty_id, &previous_status, &bounty.status);
 
@@ -134,7 +114,7 @@ impl MergeMintContract {
 
         events::emit_bounty_claimed(&env, &bounty_id, &contributor);
 
-        let mut open = storage::get_open_bounties(&env);
+        let open = storage::get_open_bounties(&env);
         let mut new_open = Vec::new(&env);
         for existing_id in open.iter() {
             if existing_id != bounty_id {
@@ -144,8 +124,6 @@ impl MergeMintContract {
         storage::set_open_bounties(&env, &new_open);
     }
 
-    /// Complete a bounty: distribute `reward_amount` proportionally across all assignees
-    /// according to their basis-point shares (shares sum to 10 000).
     pub fn complete_bounty(env: Env, verifier: Address, bounty_id: BytesN<32>) {
         verifier.require_auth();
 
@@ -160,34 +138,35 @@ impl MergeMintContract {
 
         let token = TokenClient::new(&env, &bounty.reward_token);
 
-        for (assignee, share_bp) in bounty.assignees.iter() {
-            let payout = (bounty.reward_amount as i128) * (share_bp as i128) / 10_000_i128;
-            token.transfer(&verifier, &assignee, &payout);
-
-            let mut contrib = storage::get_contributor(&env, &assignee)
-                .unwrap_or(Contributor {
-                    address: assignee.clone(),
-                    reputation: 0,
-                    total_earned: 0,
-                    contribution_count: 0,
-                    active_claims: 0,
-                    metadata: None,
-                });
-
-            contrib.reputation += 10;
-            contrib.total_earned += payout;
-            contrib.contribution_count += 1;
-            if contrib.active_claims > 0 {
-                contrib.active_claims -= 1;
+        // #270: complete any remaining milestones
+        if let Some(ref mut milestones) = bounty.milestones {
+            let (primary_assignee, _) = bounty.assignees.get(0).unwrap();
+            let mut updated = Vec::new(&env);
+            for (i, mut ms) in milestones.iter().enumerate() {
+                if !ms.completed {
+                    token.transfer(&verifier, &primary_assignee, &ms.reward);
+                    Self::credit_contributor(&env, &primary_assignee, ms.reward);
+                    storage::append_contributor_bounty(&env, &primary_assignee, &bounty_id);
+                    events::emit_milestone_completed(&env, &bounty_id, &primary_assignee, i as u32);
+                    ms.completed = true;
+                }
+                updated.push_back(ms);
             }
-
-            storage::store_contributor(&env, &assignee, &contrib);
-            events::emit_reward_paid(&env, &bounty_id, &assignee, &payout);
+            bounty.milestones = Some(updated);
+        } else {
+            // No milestones — distribute reward by basis-point shares
+            for (assignee, share_bp) in bounty.assignees.iter() {
+                let payout =
+                    (bounty.reward_amount as i128) * (share_bp as i128) / 10_000_i128;
+                token.transfer(&verifier, &assignee, &payout);
+                Self::credit_contributor(&env, &assignee, payout);
+                // #269: append to contributor bounty index
+                storage::append_contributor_bounty(&env, &assignee, &bounty_id);
+                events::emit_reward_paid(&env, &bounty_id, &assignee, &payout);
+            }
         }
 
-        // Use the first assignee as the primary for the completion event (backward compat).
         let (primary_assignee, _) = bounty.assignees.get(0).unwrap();
-
         let previous_status = bounty.status.clone();
         bounty.status = Symbol::new(&env, STATUS_COMPLETED);
         storage::store_bounty(&env, &bounty_id, &bounty);
@@ -196,12 +175,66 @@ impl MergeMintContract {
         events::emit_bounty_completed(&env, &bounty_id, &primary_assignee);
     }
 
+    /// #270: complete a single milestone by index, releasing its partial reward.
+    pub fn complete_milestone(
+        env: Env,
+        verifier: Address,
+        bounty_id: BytesN<32>,
+        milestone_index: u32,
+    ) {
+        verifier.require_auth();
+
+        let mut bounty = match storage::get_bounty(&env, &bounty_id) {
+            Some(b) => b,
+            None => panic!("{}", errors::BOUNTY_NOT_FOUND),
+        };
+
+        if bounty.assignees.is_empty() {
+            panic!("{}", errors::BOUNTY_HAS_NO_ASSIGNEE);
+        }
+
+        let milestones = match bounty.milestones {
+            Some(ref ms) => ms.clone(),
+            None => panic!("bounty has no milestones"),
+        };
+
+        let idx = milestone_index as usize;
+        if idx >= milestones.len() as usize {
+            panic!("milestone index out of range");
+        }
+
+        let mut ms = milestones.get(milestone_index).unwrap();
+        if ms.completed {
+            panic!("milestone already completed");
+        }
+
+        let (assignee, _) = bounty.assignees.get(0).unwrap();
+        let token = TokenClient::new(&env, &bounty.reward_token);
+        token.transfer(&verifier, &assignee, &ms.reward);
+
+        Self::credit_contributor(&env, &assignee, ms.reward);
+        storage::append_contributor_bounty(&env, &assignee, &bounty_id);
+
+        ms.completed = true;
+        let mut updated = Vec::new(&env);
+        for (i, m) in milestones.iter().enumerate() {
+            if i as u32 == milestone_index {
+                updated.push_back(ms.clone());
+            } else {
+                updated.push_back(m);
+            }
+        }
+        bounty.milestones = Some(updated);
+        storage::store_bounty(&env, &bounty_id, &bounty);
+
+        events::emit_milestone_completed(&env, &bounty_id, &assignee, milestone_index);
+    }
+
     pub fn raise_dispute(env: Env, caller: Address, bounty_id: BytesN<32>) {
         caller.require_auth();
 
         let mut bounty = storage::get_bounty(&env, &bounty_id).expect("bounty not found");
 
-        // Allow creator or any assignee to raise a dispute.
         let is_assignee = bounty.assignees.iter().any(|(addr, _)| addr == caller);
         if caller != bounty.creator && !is_assignee {
             panic!("only creator or assignee can raise dispute");
@@ -214,83 +247,59 @@ impl MergeMintContract {
         events::emit_bounty_disputed(&env, &bounty_id, &caller);
     }
 
-    /// Update the on-chain metadata URI for a contributor profile.
-    /// Only the contributor themselves may call this (enforced by `require_auth`).
     pub fn update_contributor_metadata(env: Env, contributor: Address, metadata: Symbol) {
         contributor.require_auth();
 
+        // #275: use Contributor::new for default construction
         let mut contrib = storage::get_contributor(&env, &contributor)
-            .unwrap_or(Contributor {
-                address: contributor.clone(),
-                reputation: 0,
-                total_earned: 0,
-                contribution_count: 0,
-                active_claims: 0,
-                metadata: None,
-            });
+            .unwrap_or_else(|| Contributor::new(contributor.clone()));
 
         contrib.metadata = Some(metadata);
         storage::store_contributor(&env, &contributor, &contrib);
     }
 
-    /// Cancel a bounty. Only the creator can cancel.
-    /// Security-critical: prevents non-creators from cancelling and potentially
-    /// triggering escrow refunds they shouldn't receive.
     pub fn cancel_bounty(env: Env, caller: Address, bounty_id: BytesN<32>) {
         caller.require_auth();
 
         let mut bounty = storage::get_bounty(&env, &bounty_id).expect("bounty not found");
 
-        // Security check: only creator can cancel
         if caller != bounty.creator {
             panic!("{}", errors::NOT_BOUNTY_CREATOR);
         }
 
-        // Guard: bounty must be open to be cancelled
         if bounty.status != Symbol::new(&env, STATUS_OPEN) {
             panic!("{}", errors::BOUNTY_NOT_OPEN);
         }
 
         bounty.status = Symbol::new(&env, STATUS_CANCELLED);
         storage::store_bounty(&env, &bounty_id, &bounty);
-
-        // Note: Escrow refund will go here once escrow is implemented.
         events::emit_bounty_cancelled(&env, &bounty_id, &caller);
     }
 
-    /// Expire an open bounty whose deadline has passed.
-    /// Design choice: permissionless — any caller can trigger expiry to keep the
-    /// open list clean without requiring the creator to be online. The caller
-    /// still needs to authenticate (require_auth) so the transaction is signed.
-    /// Once escrow is implemented this will trigger a refund to the creator.
     pub fn expire_bounty(env: Env, caller: Address, bounty_id: BytesN<32>) {
         caller.require_auth();
 
         let mut bounty = storage::get_bounty(&env, &bounty_id).expect("bounty not found");
 
-        // Guard: must have a deadline set.
         let deadline = match bounty.deadline {
             Some(d) => d,
             None => panic!("{}", errors::BOUNTY_NO_DEADLINE),
         };
 
-        // Guard: deadline must have passed.
         if env.ledger().sequence() <= deadline {
             panic!("{}", errors::DEADLINE_NOT_PASSED);
         }
 
-        // Guard: only open bounties can be expired.
         if bounty.status != Symbol::new(&env, STATUS_OPEN) {
             panic!("{}", errors::BOUNTY_NOT_OPEN);
         }
 
         bounty.status = Symbol::new(&env, STATUS_CANCELLED);
         storage::store_bounty(&env, &bounty_id, &bounty);
-
-        // Escrow refund goes here once escrow is implemented.
-
         events::emit_bounty_expired(&env, &bounty_id, &bounty.creator);
     }
+
+    // --- Read-only ---
 
     pub fn get_bounty(env: Env, bounty_id: BytesN<32>) -> Option<Bounty> {
         storage::get_bounty(&env, &bounty_id)
@@ -314,5 +323,42 @@ impl MergeMintContract {
 
     pub fn get_open_bounties(env: Env) -> Vec<BytesN<32>> {
         storage::get_open_bounties(&env)
+    }
+
+    /// #269: return the list of bounty IDs a contributor has completed.
+    pub fn get_bounties_by_contributor(env: Env, contributor: Address) -> Vec<BytesN<32>> {
+        storage::get_contributor_bounties(&env, &contributor)
+    }
+
+    /// #266: return up to `limit` bounties starting at counter index `start`.
+    pub fn get_bounties_by_range(env: Env, start: u64, limit: u64) -> Vec<Bounty> {
+        let count = storage::get_bounty_count(&env);
+        let mut result = Vec::new(&env);
+        if start >= count {
+            return result;
+        }
+        let end = (start + limit).min(count);
+        for i in start..end {
+            let id = generate_bounty_id(&env, i);
+            if let Some(bounty) = storage::get_bounty(&env, &id) {
+                result.push_back(bounty);
+            }
+        }
+        result
+    }
+
+    // --- Private helpers ---
+
+    /// #275: update contributor stats after a payout (used by complete_bounty and complete_milestone).
+    fn credit_contributor(env: &Env, assignee: &Address, payout: i128) {
+        let mut contrib = storage::get_contributor(env, assignee)
+            .unwrap_or_else(|| Contributor::new(assignee.clone()));
+        contrib.reputation += 10;
+        contrib.total_earned += payout;
+        contrib.contribution_count += 1;
+        if contrib.active_claims > 0 {
+            contrib.active_claims -= 1;
+        }
+        storage::store_contributor(env, assignee, &contrib);
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -2,57 +2,62 @@
 use soroban_sdk::{Address, BytesN, Env, Symbol};
 
 pub fn emit_bounty_created(env: &Env, bounty_id: &BytesN<32>, creator: &Address, reward: &i128) {
-    let topic = Symbol::new(env, "bounty_created");
-    env.events()
-        .publish((topic, creator.clone()), (bounty_id.clone(), *reward));
+    env.events().publish(
+        (Symbol::new(env, "bounty_created"), creator.clone()),
+        (bounty_id.clone(), *reward),
+    );
 }
 
 pub fn emit_bounty_claimed(env: &Env, bounty_id: &BytesN<32>, contributor: &Address) {
-    let topic = Symbol::new(env, "bounty_claimed");
-    env.events()
-        .publish((topic, contributor.clone()), bounty_id.clone());
-}
-
-pub fn emit_bounty_completed(env: &Env, bounty_id: &BytesN<32>, contributor: &Address) {
-    let topic = Symbol::new(env, "bounty_completed");
-    env.events()
-        .publish((topic, contributor.clone()), bounty_id.clone());
-}
-
-pub fn emit_reward_paid(env: &Env, bounty_id: &BytesN<32>, contributor: &Address, amount: &i128) {
-    let topic = Symbol::new(env, "reward_paid");
-    env.events()
-        .publish((topic, contributor.clone()), (bounty_id.clone(), *amount));
-}
-
-pub fn emit_bounty_disputed(env: &Env, bounty_id: &BytesN<32>, caller: &Address) {
-    let topic = Symbol::new(env, "bounty_disputed");
     env.events().publish(
-        (topic, caller.clone()),
+        (Symbol::new(env, "bounty_claimed"), contributor.clone()),
         bounty_id.clone(),
     );
 }
 
-pub fn emit_bounty_updated(env: &Env, bounty_id: &BytesN<32>, creator: &Address) {
-    let topic = Symbol::new(env, "bounty_updated");
+pub fn emit_bounty_completed(env: &Env, bounty_id: &BytesN<32>, contributor: &Address) {
     env.events().publish(
-        (topic, creator.clone()),
+        (Symbol::new(env, "bounty_completed"), contributor.clone()),
+        bounty_id.clone(),
+    );
+}
+
+pub fn emit_reward_paid(env: &Env, bounty_id: &BytesN<32>, contributor: &Address, amount: &i128) {
+    env.events().publish(
+        (Symbol::new(env, "reward_paid"), contributor.clone()),
+        (bounty_id.clone(), *amount),
+    );
+}
+
+pub fn emit_milestone_completed(
+    env: &Env,
+    bounty_id: &BytesN<32>,
+    contributor: &Address,
+    index: u32,
+) {
+    env.events().publish(
+        (Symbol::new(env, "milestone_completed"), contributor.clone()),
+        (bounty_id.clone(), index),
+    );
+}
+
+pub fn emit_bounty_disputed(env: &Env, bounty_id: &BytesN<32>, caller: &Address) {
+    env.events().publish(
+        (Symbol::new(env, "bounty_disputed"), caller.clone()),
         bounty_id.clone(),
     );
 }
 
 pub fn emit_bounty_cancelled(env: &Env, bounty_id: &BytesN<32>, creator: &Address) {
-    let topic = Symbol::new(env, "bounty_cancelled");
     env.events().publish(
-        (topic, creator.clone()),
+        (Symbol::new(env, "bounty_cancelled"), creator.clone()),
         bounty_id.clone(),
     );
 }
 
 pub fn emit_bounty_expired(env: &Env, bounty_id: &BytesN<32>, creator: &Address) {
-    let topic = Symbol::new(env, "bounty_expired");
     env.events().publish(
-        (topic, creator.clone()),
+        (Symbol::new(env, "bounty_expired"), creator.clone()),
         bounty_id.clone(),
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 #![no_std]
 
-pub mod errors;
 mod contract;
 mod errors;
 mod events;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,16 +1,8 @@
+// SPDX-License-Identifier: MIT
 use soroban_sdk::{Address, BytesN, Env, Symbol, Vec};
 
 use crate::types::{Bounty, BountyMeta, Contributor, DataKey};
 
-/// Returns the total number of bounties ever created.
-///
-/// Storage key: `DataKey::BountyCount`
-/// Stored type: `u64`
-/// Default value: `0` (returns 0 if no bounties have been created)
-///
-/// This is a singleton counter that monotonically increases with each
-/// `create_bounty` call. The value is used as part of the bounty ID
-/// generation to produce deterministic, unique identifiers.
 pub fn get_bounty_count(env: &Env) -> u64 {
     env.storage()
         .persistent()
@@ -18,40 +10,16 @@ pub fn get_bounty_count(env: &Env) -> u64 {
         .unwrap_or(0)
 }
 
-/// Sets the global bounty counter to a new value.
-///
-/// Storage key: `DataKey::BountyCount`
-/// Stored type: `u64`
-///
-/// This should only be called from `create_bounty` when incrementing the
-/// counter after a new bounty has been stored. Setting arbitrary values
-/// could break the monotonicity of bounty IDs.
 pub fn set_bounty_count(env: &Env, count: &u64) {
     env.storage().persistent().set(&DataKey::BountyCount, count);
 }
 
-/// Persists a `Bounty` struct under its unique 32-byte identifier.
-///
-/// Storage key: `DataKey::Bounty(id)`
-/// Stored type: `Bounty`
-/// Side effects: Overwrites any existing entry for the same `id`.
-///
-/// This is called during `create_bounty` (initial store) and
-/// `claim_bounty` (when the assignee and status are updated).
 pub fn store_bounty(env: &Env, id: &BytesN<32>, bounty: &Bounty) {
     env.storage()
         .persistent()
         .set(&DataKey::Bounty(id.clone()), bounty);
 }
 
-/// Retrieves a `Bounty` by its 32-byte identifier, if it exists.
-///
-/// Storage key: `DataKey::Bounty(id)`
-/// Stored type: `Bounty`
-/// Returns: `Some(Bounty)` if found, `None` if no bounty exists for `id`.
-///
-/// Callers should handle the `None` case (e.g., by panicking with a
-/// descriptive message as done in `claim_bounty` and `complete_bounty`).
 pub fn get_bounty(env: &Env, id: &BytesN<32>) -> Option<Bounty> {
     env.storage().persistent().get(&DataKey::Bounty(id.clone()))
 }
@@ -68,34 +36,32 @@ pub fn get_bounty_meta(env: &Env, id: &BytesN<32>) -> Option<BountyMeta> {
         .get(&DataKey::BountyMeta(id.clone()))
 }
 
-/// Persists a `Contributor` profile under the contributor's wallet address.
-///
-/// Storage key: `DataKey::Contributor(address)`
-/// Stored type: `Contributor`
-/// Side effects: Overwrites the previous entry for the same `address`.
-///
-/// Called during `complete_bounty` to update reputation, total earned,
-/// and contribution count. Creates a new entry (via `unwrap_or`) if the
-/// contributor hasn't been recorded yet.
 pub fn store_contributor(env: &Env, address: &Address, contributor: &Contributor) {
     env.storage()
         .persistent()
         .set(&DataKey::Contributor(address.clone()), contributor);
 }
 
-/// Retrieves a `Contributor` profile by wallet address, if it exists.
-///
-/// Storage key: `DataKey::Contributor(address)`
-/// Stored type: `Contributor`
-/// Returns: `Some(Contributor)` if found, `None` if the address has never
-/// completed a bounty.
-///
-/// Callers should use `unwrap_or` with a default `Contributor` when a
-/// fresh profile is needed (see `complete_bounty` for an example).
 pub fn get_contributor(env: &Env, address: &Address) -> Option<Contributor> {
     env.storage()
         .persistent()
         .get(&DataKey::Contributor(address.clone()))
+}
+
+// #269: contributor bounty index
+pub fn get_contributor_bounties(env: &Env, address: &Address) -> Vec<BytesN<32>> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ContributorBounties(address.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn append_contributor_bounty(env: &Env, address: &Address, bounty_id: &BytesN<32>) {
+    let mut list = get_contributor_bounties(env, address);
+    list.push_back(bounty_id.clone());
+    env.storage()
+        .persistent()
+        .set(&DataKey::ContributorBounties(address.clone()), &list);
 }
 
 pub fn get_bounties_by_status(env: &Env, status: &Symbol) -> Vec<BytesN<32>> {
@@ -113,24 +79,20 @@ pub fn set_bounties_by_status(env: &Env, status: &Symbol, bounties: &Vec<BytesN<
 
 pub fn add_bounty_to_status(env: &Env, bounty_id: &BytesN<32>, status: &Symbol) {
     let mut current = get_bounties_by_status(env, status);
-
-    if current.iter().all(|existing_id| existing_id != *bounty_id) {
+    if current.iter().all(|id| id != *bounty_id) {
         current.push_back(bounty_id.clone());
     }
-
     set_bounties_by_status(env, status, &current);
 }
 
 pub fn remove_bounty_from_status(env: &Env, bounty_id: &BytesN<32>, status: &Symbol) {
     let current = get_bounties_by_status(env, status);
     let mut updated = Vec::new(env);
-
-    for existing_id in current.iter() {
-        if existing_id != *bounty_id {
-            updated.push_back(existing_id);
+    for id in current.iter() {
+        if id != *bounty_id {
+            updated.push_back(id);
         }
     }
-
     set_bounties_by_status(env, status, &updated);
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -8,83 +8,62 @@ pub enum DataKey {
     Bounty(BytesN<32>),
     BountyMeta(BytesN<32>),
     Contributor(Address),
+    ContributorBounties(Address),
     StatusIndex(Symbol),
     OpenBounties,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
+pub struct Milestone {
+    pub description: Symbol,
+    pub reward: i128,
+    pub completed: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
 pub struct Bounty {
-    /// The wallet address of the maintainer who created this bounty.
-    /// Only this address may update or cancel the bounty.
     pub creator: Address,
-    /// The total reward in raw token units (not human-readable decimals).
-    /// For a token with 7 decimal places, a value of `1_000_000_0` equals 1.0 token.
-    /// Must be positive (> 0); enforced by `create_bounty`.
     pub reward_amount: i128,
-    /// The contract address of the Soroban token used to pay the reward
-    /// (e.g. USDC, XLM native asset contract). Must implement the Soroban
-    /// token interface (`transfer`, `balance`).
     pub reward_token: Address,
-    /// The list of contributors who have claimed this bounty, each paired with
-    /// their basis-point share of the reward (shares must sum to 10 000).
-    /// Empty while the bounty is `"open"`; populated by `claim_bounty` calls.
     pub assignees: Vec<(Address, u32)>,
-    /// Maximum number of contributors allowed to claim this bounty.
-    /// Once `assignees.len() == max_assignees` the bounty is no longer claimable.
     pub max_assignees: u32,
-    /// Lifecycle state of the bounty. Valid values and transitions:
-    /// - `"open"` — initial state after `create_bounty`
-    /// - `"in_progress"` — at least one contributor has claimed via `claim_bounty`
-    /// - `"completed"` — reward distributed via `complete_bounty`
-    /// - `"disputed"` — raised by creator or assignee via `raise_dispute`
-    /// - `"cancelled"` — cancelled by creator or expired past deadline
-    ///
-    /// Exposed in the contract type for off-chain indexers; internal contract
-    /// logic derives state from `assignees` presence and explicit status writes.
     #[allow(dead_code)]
     pub status: Symbol,
-    /// Minimum reputation score a contributor must hold to claim this bounty.
-    /// A value of `0` means any contributor can claim regardless of reputation.
-    /// Reputation is a monotonically increasing `u32` (+10 per completed bounty).
     pub min_reputation: u32,
-    /// Optional ledger sequence number after which the bounty cannot be claimed.
-    /// If set, claim_bounty will reject claims from contributors once the ledger
-    /// sequence number exceeds this value.
     pub deadline: Option<u32>,
+    pub milestones: Option<Vec<Milestone>>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub struct BountyMeta {
-    /// Short human-readable title for the bounty (max 32 chars, Soroban `Symbol` limit).
     pub title: Symbol,
-    /// Longer description of the work required to complete the bounty.
     pub description: Symbol,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
 pub struct Contributor {
-    /// The wallet address that identifies this contributor on-chain.
-    /// Stored so off-chain consumers can identify the contributor from the
-    /// struct alone without keying back through storage.
     #[allow(dead_code)]
     pub address: Address,
-    /// Reputation score accumulated through completed bounties.
-    /// Incremented by +10 for every successfully completed bounty.
-    /// Monotonically increasing — never decreases.
     pub reputation: u32,
-    /// Cumulative raw token units earned across all completed bounties.
-    /// Uses the same unit as `Bounty::reward_amount` (raw, not human-readable).
     pub total_earned: i128,
-    /// Total number of bounties this contributor has successfully completed.
     pub contribution_count: u32,
-    /// Number of bounties the contributor has claimed but not yet completed.
-    /// Limited to 1 concurrent active claim; `claim_bounty` will panic if > 0.
     pub active_claims: u32,
-    /// Optional URI pointing to an off-chain profile document (e.g. an IPFS
-    /// link to a JSON file with name, avatar, and GitHub username).
-    /// Controlled and updatable by the contributor via `update_contributor_metadata`.
     pub metadata: Option<Symbol>,
+}
+
+impl Contributor {
+    pub fn new(address: Address) -> Self {
+        Self {
+            address,
+            reputation: 0,
+            total_earned: 0,
+            contribution_count: 0,
+            active_claims: 0,
+            metadata: None,
+        }
+    }
 }


### PR DESCRIPTION
#275: extract Contributor::new associated function; replace all
      inline Contributor { ... } literals with Contributor::new()
#266: add get_bounties_by_range(start, limit) for paginated listing;
      reconstructs IDs from counter, returns Vec<Bounty>
#269: add DataKey::ContributorBounties, storage helpers
      get_contributor_bounties / append_contributor_bounty;
      append in complete_bounty; expose get_bounties_by_contributor
#270: add Milestone { description, reward, completed } type;
      add milestones: Option<Vec<Milestone>> to Bounty;
      add complete_milestone for per-milestone partial payouts;
      emit milestone_completed event per milestone;
      complete_bounty completes all remaining milestones in one call
Also: fix duplicate mod errors in lib.rs, remove stale assignee/
      assignees confusion, dedup previous_status binding, add
      credit_contributor helper to centralise reputation updates

Closes #275 
Closes #266 
Closes #269 
Closes #270 