### PR TITLE
fix: correct getBountyCount return-type handling in SDK (#530)

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -178,7 +178,7 @@ export class MergeMintSDK {
   async getBountyCount(): Promise<bigint> {
     const result = await this.simulateReadCall("get_bounty_count", []);
     if (!result) return 0n;
-    return BigInt(scValToNative(result) as string);
+    return BigInt(scValToNative(result) as string | number | bigint);
   }
 
   async getOpenBounties(): Promise<string[]> {


### PR DESCRIPTION
### Fix getBountyCount's Misleading Return-Type Cast (#530)

- Updated return-type assertion in sdk/src/index.ts:getBountyCount from s string to s string | number | bigint to cleanly support native Soroban u64 return types.

Payout Wallet (EVM): 0x20d3ea74f5534c760fb94753cfa3f4b7fce4d17f

Fixes #530