### PR TITLE
fix: validate Symbol length before encoding in SDK (#531)

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -70,6 +70,9 @@ function addressToScVal(address: string): xdr.ScVal {
 }
 
 function symbolToScVal(value: string): xdr.ScVal {
+  if (value.length > 32) {
+    throw new Error(`value exceeds 32-character Symbol limit: ${value}`);
+  }
   return nativeToScVal(value, { type: "symbol" });
 }
 


### PR DESCRIPTION
Validate Symbol Length Before Encoding in SDK (#531)

Added 32-character Symbol length validation guard in symbolToScVal.

Payout Wallet (EVM): 0x20d3ea74f5534c760fb94753cfa3f4b7fce4d17f

Fixes #531