### PR TITLE
fix: make MAINNET placeholder RPC URL fail with a clear error instead of silently (#532)

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -142,6 +142,9 @@ export class MergeMintSDK {
   private readonly contractId: string;
 
   constructor(config: NetworkConfig) {
+    if (config.rpcUrl.includes("XCa...") || config.rpcUrl.includes("...")) {
+      throw new Error("Invalid RPC URL: placeholder detected in configuration. Please provide a valid Soroban RPC provider URL.");
+    }
     this.rpc = new SorobanRpc.Server(config.rpcUrl);
     this.contract = new Contract(config.contractId);
     this.networkPassphrase = config.networkPassphrase;


### PR DESCRIPTION
Make MAINNET Placeholder RPC URL Fail Safely (#532)

Added runtime check in MergeMintSDK constructor to throw clear error when given placeholder RPC URL.

Payout Wallet (EVM): 0x20d3ea74f5534c760fb94753cfa3f4b7fce4d17f

Fixes #532