### PR TITLE
docs: reconcile stale security/ stub docs with docs/security.md (#527)

### DIFF
--- a/security/minimum-reputation-enforcement.md
+++ b/security/minimum-reputation-enforcement.md
@@ -1,8 +1,6 @@
 # Security: Enforce Minimum Reputation Threshold
 
-## Issue
-No minimum reputation for claimers.
+**Status**: Implemented in contract (see [docs/security.md](../docs/security.md) Threat #1).
 
-## Fix
-- Add reputation check before claim
-- Configurable threshold
+## Summary
+The `min_reputation` check is fully enforced during `claim_bounty` calls to prevent unverified accounts from claiming high-value tasks.

--- a/security/prevent-creator-claim.md
+++ b/security/prevent-creator-claim.md
@@ -1,8 +1,6 @@
-# Security: Prevent Bounty Creator From Claiming
+# Security: Prevent Creator Self-Claim
 
-## Issue
-Bounty creator could claim their own bounty.
+**Status**: Implemented in contract (see [docs/security.md](../docs/security.md) Threat #2).
 
-## Fix
-- Add `require(creator != msg.sender)` check
-- Validate claimer is not the original funder
+## Summary
+Creator self-claiming is strictly prevented in `claim_bounty` to eliminate wash trading and self-rewarding exploits.

--- a/security/validate-reward-token-address.md
+++ b/security/validate-reward-token-address.md
@@ -1,8 +1,6 @@
 # Security: Validate Reward Token Address
 
-## Issue
-reward_token address not validated.
+**Status**: Implemented in contract (see [docs/security.md](../docs/security.md) Threat #3).
 
-## Fix
-- Add address(0) check
-- Validate token contract exists
+## Summary
+Reward token contract addresses are validated during bounty creation to prevent zero-address or invalid asset escrow initialization.


### PR DESCRIPTION
Reconcile Stale security/ Stub Docs with docs/security.md (#527)

Updated security stubs with status lines and cross-references to docs/security.md.

Payout Wallet (EVM): 0x20d3ea74f5534c760fb94753cfa3f4b7fce4d17f

Fixes #527