### PR TITLE
feat: add Dockerfile/compose setup for local onboarding (#529)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  mergemint-backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - RUST_LOG=info
+      - DATABASE_URL=sqlite://mergemint.db
+      - NETWORK_PASSPHRASE=Test SDF Network ; September 2015
+    restart: unless-stopped
+
+  mergemint-frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      - VITE_BACKEND_URL=http://localhost:8080
+    depends_on:
+      - mergemint-backend
+    restart: unless-stopped


### PR DESCRIPTION
Add a Dockerfile/compose setup for local onboarding (#529)

Added docker-compose.yml with:
- Backend and frontend compose service wiring

Payout Wallet (EVM): 0x20d3ea74f5534c760fb94753cfa3f4b7fce4d17f

Fixes #529