### PR TITLE
fix: validate network passphrase against deployed contract at startup

### DIFF
--- a/backend/src/health.ts
+++ b/backend/src/health.ts
@@ -1,0 +1,8 @@
+// Exposes the backend's configured network passphrase via /api/health so
+// the frontend can detect and warn on a NETWORK_PASSPHRASE mismatch.
+export function buildHealthResponse(configuredPassphrase: string) {
+  return {
+    status: "ok",
+    networkPassphrase: configuredPassphrase,
+  };
+}

--- a/backend/src/validateNetworkPassphrase.ts
+++ b/backend/src/validateNetworkPassphrase.ts
@@ -1,0 +1,24 @@
+import { SorobanRpc } from "@stellar/stellar-sdk";
+
+export interface NetworkPassphraseCheckConfig {
+  rpcUrl: string;
+  configuredPassphrase: string;
+}
+
+// Fails fast on startup if NETWORK_PASSPHRASE doesn't match the network the
+// configured RPC endpoint actually serves, instead of failing silently on
+// the first signed transaction.
+export async function validateNetworkPassphrase(
+  config: NetworkPassphraseCheckConfig,
+): Promise<void> {
+  const rpc = new SorobanRpc.Server(config.rpcUrl);
+  const { passphrase: actualPassphrase } = await rpc.getNetwork();
+
+  if (actualPassphrase !== config.configuredPassphrase) {
+    throw new Error(
+      `NETWORK_PASSPHRASE mismatch: configured "${config.configuredPassphrase}" ` +
+        `but RPC endpoint ${config.rpcUrl} reports "${actualPassphrase}". ` +
+        "Update NETWORK_PASSPHRASE to match the network the contract was deployed to.",
+    );
+  }
+}


### PR DESCRIPTION
Closes #526

---

## Summary
- Added `backend/src/validateNetworkPassphrase.ts`: on startup, compares the configured `NETWORK_PASSPHRASE` against the network reported by the RPC endpoint and fails fast with a clear error on mismatch.
- Added `backend/src/health.ts`: exposes the backend's configured passphrase for a `/api/health` endpoint so the frontend can warn on mismatch too.

## Note
- This repo checkout did not previously have a `backend/` directory, so these are new standalone modules matching the issue's described behavior. They are not yet wired into an actual server/startup entrypoint — please integrate at the appropriate call site before merging.

## Test plan
- [ ] Start the backend with a deliberately wrong passphrase and confirm it fails fast with a clear message instead of failing silently on the first signed transaction