### PR TITLE
Feat/frontend bounty UI batch

### DIFF
--- a/frontend/src/components/BountyCard.tsx
+++ b/frontend/src/components/BountyCard.tsx
@@ -1,0 +1,22 @@
+import { Bounty } from "../lib/types";
+import { shortenAddress } from "../lib/format";
+import { CopyButton } from "./CopyButton";
+
+export function BountyCard({ bounty }: { bounty: Bounty }) {
+  return (
+    <div className="bounty-card">
+      <span className="bounty-card__id" title={bounty.id}>
+        {shortenAddress(bounty.id)}
+        <CopyButton value={bounty.id} />
+      </span>
+      <span className="bounty-card__creator" title={bounty.creator}>
+        {shortenAddress(bounty.creator)}
+        <CopyButton value={bounty.creator} />
+      </span>
+      <span className="bounty-card__reward">
+        {bounty.rewardAmount.toString()} {bounty.rewardToken}
+      </span>
+      <span className="bounty-card__status">{bounty.status}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/BountyDetail.tsx
+++ b/frontend/src/components/BountyDetail.tsx
@@ -26,6 +26,10 @@ export function BountyDetail({ bounty, network, onClaim }: BountyDetailProps) {
       </p>
       <p>Status: {bounty.status}</p>
 
+      {/* Stub only — the listed-vs-non-listed verifier approval flow activates once
+          contract issue #11 (multi-sig verifiers) ships. */}
+      <p className="bounty-detail__multisig-note">Verifiers: single-approver (multi-sig not yet enabled)</p>
+
       <ul className="assignee-list">
         {bounty.assignees.map((assignee) => (
           <li key={assignee.address}>

--- a/frontend/src/components/BountyDetail.tsx
+++ b/frontend/src/components/BountyDetail.tsx
@@ -1,6 +1,8 @@
 import { useTxFlow } from "../hooks/useTxFlow";
 import { TxResultBanner } from "./TxResultBanner";
+import { CopyButton } from "./CopyButton";
 import { Bounty, NetworkName } from "../lib/types";
+import { shortenAddress } from "../lib/format";
 
 interface BountyDetailProps {
   bounty: Bounty;
@@ -18,13 +20,19 @@ export function BountyDetail({ bounty, network, onClaim }: BountyDetailProps) {
   return (
     <div className="bounty-detail">
       <h2>{bounty.rewardAmount.toString()} {bounty.rewardToken}</h2>
-      <p>Creator: {bounty.creator}</p>
+      <p>
+        Creator: <span title={bounty.creator}>{shortenAddress(bounty.creator)}</span>
+        <CopyButton value={bounty.creator} />
+      </p>
       <p>Status: {bounty.status}</p>
 
       <ul className="assignee-list">
         {bounty.assignees.map((assignee) => (
           <li key={assignee.address}>
-            {assignee.address} — {(assignee.shareBp / 100).toFixed(2)}%
+            <span title={assignee.address}>{shortenAddress(assignee.address)}</span>
+            <CopyButton value={assignee.address} />
+            {" — "}
+            {(assignee.shareBp / 100).toFixed(2)}%
           </li>
         ))}
       </ul>

--- a/frontend/src/components/BountyDetail.tsx
+++ b/frontend/src/components/BountyDetail.tsx
@@ -1,0 +1,40 @@
+import { useTxFlow } from "../hooks/useTxFlow";
+import { TxResultBanner } from "./TxResultBanner";
+import { Bounty, NetworkName } from "../lib/types";
+
+interface BountyDetailProps {
+  bounty: Bounty;
+  network: NetworkName;
+  onClaim: (bountyId: string) => Promise<{ hash: string }>;
+}
+
+export function BountyDetail({ bounty, network, onClaim }: BountyDetailProps) {
+  const { pending, error, result, run } = useTxFlow(network);
+
+  async function perform() {
+    await run(() => onClaim(bounty.id));
+  }
+
+  return (
+    <div className="bounty-detail">
+      <h2>{bounty.rewardAmount.toString()} {bounty.rewardToken}</h2>
+      <p>Creator: {bounty.creator}</p>
+      <p>Status: {bounty.status}</p>
+
+      <ul className="assignee-list">
+        {bounty.assignees.map((assignee) => (
+          <li key={assignee.address}>
+            {assignee.address} — {(assignee.shareBp / 100).toFixed(2)}%
+          </li>
+        ))}
+      </ul>
+
+      <button onClick={perform} disabled={pending}>
+        {pending ? "Submitting…" : "Claim"}
+      </button>
+
+      {error && <p className="error">{error}</p>}
+      <TxResultBanner result={result} />
+    </div>
+  );
+}

--- a/frontend/src/components/CopyButton.tsx
+++ b/frontend/src/components/CopyButton.tsx
@@ -1,0 +1,23 @@
+import { useState } from "react";
+
+export function CopyButton({ value }: { value: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  }
+
+  return (
+    <button
+      type="button"
+      className="copy-button"
+      title={value}
+      onClick={handleCopy}
+      aria-label="Copy to clipboard"
+    >
+      {copied ? "Copied!" : "⧉"}
+    </button>
+  );
+}

--- a/frontend/src/components/CreateBounty.tsx
+++ b/frontend/src/components/CreateBounty.tsx
@@ -12,6 +12,9 @@ export function CreateBounty({ network, onSubmit }: CreateBountyProps) {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [rewardAmount, setRewardAmount] = useState("");
+  const [multisigOpen, setMultisigOpen] = useState(false);
+  const [verifiers, setVerifiers] = useState<string[]>([""]);
+  const [threshold, setThreshold] = useState(1);
   const { pending, error, result, run } = useTxFlow(network);
 
   async function perform() {
@@ -38,6 +41,55 @@ export function CreateBounty({ network, onSubmit }: CreateBountyProps) {
         Reward amount
         <input value={rewardAmount} onChange={(e) => setRewardAmount(e.target.value)} />
       </label>
+
+      {/* Stub UI only — wire up once contract issue #11 (multi-sig verifiers) ships. */}
+      <details
+        className="create-bounty__advanced"
+        open={multisigOpen}
+        onToggle={(e) => setMultisigOpen((e.target as HTMLDetailsElement).open)}
+      >
+        <summary>Advanced: multi-sig verifiers</summary>
+
+        {verifiers.map((verifier, i) => (
+          <div className="verifier-row" key={i}>
+            <input
+              placeholder="Verifier address"
+              value={verifier}
+              onChange={(e) => {
+                const next = [...verifiers];
+                next[i] = e.target.value;
+                setVerifiers(next);
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => setVerifiers(verifiers.filter((_, idx) => idx !== i))}
+              disabled={verifiers.length <= 1}
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+        <button type="button" onClick={() => setVerifiers([...verifiers, ""])}>
+          Add verifier
+        </button>
+
+        <label>
+          Approval threshold
+          <select value={threshold} onChange={(e) => setThreshold(Number(e.target.value))}>
+            {verifiers.map((_, i) => (
+              <option key={i} value={i + 1}>
+                {i + 1} of {verifiers.length}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <p className="create-bounty__advanced-note">
+          Multi-sig verification is not yet enforced on-chain — this form does not submit these
+          fields until contract issue #11 ships.
+        </p>
+      </details>
 
       <button type="submit" disabled={pending}>
         {pending ? "Submitting…" : "Create bounty"}

--- a/frontend/src/components/CreateBounty.tsx
+++ b/frontend/src/components/CreateBounty.tsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+import { useTxFlow } from "../hooks/useTxFlow";
+import { TxResultBanner } from "./TxResultBanner";
+import { NetworkName } from "../lib/types";
+
+interface CreateBountyProps {
+  network: NetworkName;
+  onSubmit: (form: { title: string; description: string; rewardAmount: string }) => Promise<{ hash: string }>;
+}
+
+export function CreateBounty({ network, onSubmit }: CreateBountyProps) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [rewardAmount, setRewardAmount] = useState("");
+  const { pending, error, result, run } = useTxFlow(network);
+
+  async function perform() {
+    await run(() => onSubmit({ title, description, rewardAmount }));
+  }
+
+  return (
+    <form
+      className="create-bounty"
+      onSubmit={(e) => {
+        e.preventDefault();
+        perform();
+      }}
+    >
+      <label>
+        Title
+        <input value={title} onChange={(e) => setTitle(e.target.value)} />
+      </label>
+      <label>
+        Description
+        <textarea value={description} onChange={(e) => setDescription(e.target.value)} />
+      </label>
+      <label>
+        Reward amount
+        <input value={rewardAmount} onChange={(e) => setRewardAmount(e.target.value)} />
+      </label>
+
+      <button type="submit" disabled={pending}>
+        {pending ? "Submitting…" : "Create bounty"}
+      </button>
+
+      {error && <p className="error">{error}</p>}
+      <TxResultBanner result={result} />
+    </form>
+  );
+}

--- a/frontend/src/components/CreateBounty.tsx
+++ b/frontend/src/components/CreateBounty.tsx
@@ -15,6 +15,7 @@ export function CreateBounty({ network, onSubmit }: CreateBountyProps) {
   const [multisigOpen, setMultisigOpen] = useState(false);
   const [verifiers, setVerifiers] = useState<string[]>([""]);
   const [threshold, setThreshold] = useState(1);
+  const [maxAssignees, setMaxAssignees] = useState(1);
   const { pending, error, result, run } = useTxFlow(network);
 
   async function perform() {
@@ -40,6 +41,22 @@ export function CreateBounty({ network, onSubmit }: CreateBountyProps) {
       <label>
         Reward amount
         <input value={rewardAmount} onChange={(e) => setRewardAmount(e.target.value)} />
+      </label>
+
+      {/* Stub UI only — wire up once contract issues #9/#10 (multi-assignee) ship. */}
+      <label>
+        Max assignees
+        <input
+          type="number"
+          min={1}
+          value={maxAssignees}
+          onChange={(e) => setMaxAssignees(Number(e.target.value))}
+        />
+        <span className="create-bounty__hint">
+          When more than one assignee is allowed, the reward is split across claimants by share
+          (see the assignee list on the bounty detail page). Not yet enforced on-chain — pending
+          contract issues #9/#10.
+        </span>
       </label>
 
       {/* Stub UI only — wire up once contract issue #11 (multi-sig verifiers) ships. */}

--- a/frontend/src/components/TxResultBanner.tsx
+++ b/frontend/src/components/TxResultBanner.tsx
@@ -1,0 +1,19 @@
+import { SubmitResult } from "../lib/types";
+import { explorerTxUrl } from "../lib/network";
+
+export function TxResultBanner({ result }: { result: SubmitResult | null }) {
+  if (!result) return null;
+
+  return (
+    <div className="tx-result-banner">
+      Transaction submitted —{" "}
+      <a
+        href={explorerTxUrl(result.hash, result.network)}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        view on Stellar Expert
+      </a>
+    </div>
+  );
+}

--- a/frontend/src/components/WalletConnectButton.tsx
+++ b/frontend/src/components/WalletConnectButton.tsx
@@ -1,0 +1,24 @@
+import { shortenAddress } from "../lib/format";
+import { CopyButton } from "./CopyButton";
+
+interface WalletConnectButtonProps {
+  address: string | null;
+  onConnect: () => void;
+}
+
+export function WalletConnectButton({ address, onConnect }: WalletConnectButtonProps) {
+  if (!address) {
+    return (
+      <button className="wallet-connect" onClick={onConnect}>
+        Connect wallet
+      </button>
+    );
+  }
+
+  return (
+    <span className="wallet-connect wallet-connect--connected">
+      <span title={address}>{shortenAddress(address)}</span>
+      <CopyButton value={address} />
+    </span>
+  );
+}

--- a/frontend/src/hooks/useTxFlow.ts
+++ b/frontend/src/hooks/useTxFlow.ts
@@ -1,0 +1,32 @@
+import { useState } from "react";
+import { SubmitResult, NetworkName } from "../lib/types";
+
+interface TxFlowState {
+  pending: boolean;
+  error: string | null;
+  result: SubmitResult | null;
+}
+
+export function useTxFlow(network: NetworkName) {
+  const [state, setState] = useState<TxFlowState>({
+    pending: false,
+    error: null,
+    result: null,
+  });
+
+  async function run(submit: () => Promise<{ hash: string; ledger?: number }>) {
+    setState({ pending: true, error: null, result: null });
+    try {
+      const { hash, ledger } = await submit();
+      const result: SubmitResult = { hash, network, ledger };
+      setState({ pending: false, error: null, result });
+      return result;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Transaction failed";
+      setState({ pending: false, error: message, result: null });
+      throw err;
+    }
+  }
+
+  return { ...state, run };
+}

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -1,0 +1,4 @@
+export function shortenAddress(address: string, lead = 4, trail = 4): string {
+  if (address.length <= lead + trail) return address;
+  return `${address.slice(0, lead)}…${address.slice(-trail)}`;
+}

--- a/frontend/src/lib/network.ts
+++ b/frontend/src/lib/network.ts
@@ -1,0 +1,10 @@
+import { NetworkName } from "./types";
+
+const EXPLORER_BASE: Record<NetworkName, string> = {
+  testnet: "https://stellar.expert/explorer/testnet",
+  mainnet: "https://stellar.expert/explorer/public",
+};
+
+export function explorerTxUrl(hash: string, network: NetworkName): string {
+  return `${EXPLORER_BASE[network]}/tx/${hash}`;
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,0 +1,24 @@
+export interface Assignee {
+  address: string;
+  shareBp: number;
+}
+
+export interface Bounty {
+  id: string;
+  creator: string;
+  rewardAmount: bigint;
+  rewardToken: string;
+  assignees: Assignee[];
+  maxAssignees: number;
+  status: string;
+  minReputation: number;
+  deadline: number | null;
+}
+
+export type NetworkName = "testnet" | "mainnet";
+
+export interface SubmitResult {
+  hash: string;
+  network: NetworkName;
+  ledger?: number;
+}


### PR DESCRIPTION
## Summary of Changes

<!-- Describe what this PR changes and why. -->
Branch feat/frontend-bounty-ui-batch (pushed to origin), 4 commits. Since this repo (mergemint-contracts) had no frontend at all, a new frontend/src/ scaffold was created from scratch, shaped around the Bounty/Contributor types already defined in sdk/src/index.ts. This code is untested and unbuilt — no build tooling, package.json, or app shell was set up; it's component/hook source only.

---
Commit 1 — feat: link submitted transaction hash to block explorer

Addresses: after a successful transaction, users had no way to see it on a block explorer.

New files:
- frontend/src/lib/types.ts — Bounty, Assignee, NetworkName ("testnet" | "mainnet"), and SubmitResult ({ hash, network, ledger? }).
- frontend/src/lib/network.ts — explorerTxUrl(hash, network) builds a Stellar Expert URL, switching base path between stellar.expert/explorer/testnet and .../public depending on network.
- frontend/src/hooks/useTxFlow.ts — useTxFlow(network) hook wrapping an async submit() call, tracking { pending, error, result } state and returning a SubmitResult with the tx hash on success.
- frontend/src/components/TxResultBanner.tsx — renders an inline banner with a link ("view on Stellar Expert") once a SubmitResult is present; renders nothing otherwise.
- frontend/src/components/CreateBounty.tsx (base version) — form with title/description/reward-amount fields, calls useTxFlow on submit, shows TxResultBanner on success.
- frontend/src/components/BountyDetail.tsx (base version) — displays bounty reward/creator/status/assignee list, a "Claim" button wired through useTxFlow, and TxResultBanner on success.

Not done: toast notifications (issue #100) — used an inline banner instead, as the issue suggested as an alternative.

---
Commit 2 — feat: add copy-to-clipboard for addresses and bounty IDs

Addresses: shortened addresses (via shortenAddress) had no way to copy the full value except via title tooltip or page source.

New files:
- frontend/src/lib/format.ts — shortenAddress(address, lead=4, trail=4), truncates to abcd…wxyz form.
- frontend/src/components/CopyButton.tsx — small icon button using navigator.clipboard.writeText(); shows "Copied!" for 1.5s after a successful copy, then reverts.
- frontend/src/components/WalletConnectButton.tsx — shows "Connect wallet" when disconnected; once connected, shows the shortened address plus a CopyButton.
- frontend/src/components/BountyCard.tsx — card showing shortened bounty ID and creator address, each with an adjacent CopyButton, plus reward amount and status.

Modified:
- BountyDetail.tsx — creator address and each assignee address now render via shortenAddress with a CopyButton next to them (previously showed the raw un-shortened address).

---
Commit 3 — feat: add multi-sig verifier configuration to create-bounty form

Per your direction, this is stub UI only — the underlying contract support (issue #11) hasn't shipped, so there's nothing real to wire it to.

Modified CreateBounty.tsx:
- Added a collapsible (<details>) "Advanced: multi-sig verifiers" section, closed by default.
- Repeatable verifier address input list (add/remove rows, minimum one row).
- An approval-threshold <select> that ranges from 1 to the current verifier count (e.g. "2 of 3").
- An explicit note that this section is not enforced on-chain and its values are not submitted with the form yet.

Modified BountyDetail.tsx:
- Added a one-line note under the bounty status ("Verifiers: single-approver (multi-sig not yet enabled)") flagging that the listed-vs-non-listed verifier approval flow doesn't exist yet.

Not implemented: any actual approval-flow logic, since there's no contract method to call.

---
Commit 4 — feat: add multi-assignee UI to create-bounty form

Also stub UI only — blocked on contract issues #9/#10.

Modified CreateBounty.tsx:
- Added a max_assignees number input (min 1) with inline help text explaining that reward splits across multiple assignees by share, and that this isn't enforced on-chain yet.

Already satisfied by Commit 1/2: the issue also asked to verify BountyDetail.tsx's assignee percentage list renders correctly for multi-assignee data — the list added in Commit 1 (bounty.assignees.map(...) rendering shareBp / 100 as a percentage) already handles an arbitrary number of assignees, so no further change was needed there.

## Related Issue

Closes #513
Closes #515
Closes #516
Closes #517

## How to Test

<!-- Steps to verify this change works correctly. -->

1. 
2. 

## Screenshots / Output

<!-- Paste relevant command output, test results, or screenshots. -->

## Checklist

- [ ] Tests added or updated
- [ ] `cargo clippy` passes with no warnings
- [ ] `cargo fmt` applied
- [ ] PR description includes `Closes #<issue_id>`
