### PR TITLE
chore: remove stale dead_code annotation on Bounty.status [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -51,7 +51,6 @@ pub struct Bounty {
     pub reward_token: Address,
     pub assignees: Vec<(Address, u32)>,
     pub max_assignees: u32,
-    #[allow(dead_code)]
     pub status: Symbol,
     pub min_reputation: u32,
     pub deadline: Option<u32>,


### PR DESCRIPTION
The `status` field on `Bounty` is actively read and written throughout `mutations.rs` — the `#[allow(dead_code)]` annotation was misleading and no longer needed.

Closes #425