### PR TITLE
chore: resolve unused Milestone struct with TODO annotation [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -37,6 +37,7 @@ pub enum DataKey {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
+// TODO(#427): unused until milestone-based partial bounty completion lands
 pub struct Milestone {
     pub description: Symbol,
     pub reward: i128,


### PR DESCRIPTION
The `Milestone` struct is defined in `types.rs` but never used anywhere in the crate. Rather than removing it outright (milestone-based partial completion is planned in #427), annotate it with a TODO referencing the tracking issue.

Closes #426