### PR TITLE
fix: extend TTL on Approvals storage entries [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -153,16 +153,22 @@ pub fn move_bounty_status(
 }
 
 pub fn get_approvals(env: &Env, bounty_id: &BountyId) -> Vec<Address> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::Approvals(bounty_id.clone()))
-        .unwrap_or_else(|| Vec::new(env))
+    let key = DataKey::Approvals(bounty_id.clone());
+    let result: Option<Vec<Address>> = env.storage().persistent().get(&key);
+    if result.is_some() {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, STORAGE_TTL_THRESHOLD, STORAGE_TTL_LEDGERS);
+    }
+    result.unwrap_or_else(|| Vec::new(env))
 }
 
 pub fn set_approvals(env: &Env, bounty_id: &BountyId, approvals: &Vec<Address>) {
+    let key = DataKey::Approvals(bounty_id.clone());
+    env.storage().persistent().set(&key, approvals);
     env.storage()
         .persistent()
-        .set(&DataKey::Approvals(bounty_id.clone()), approvals);
+        .extend_ttl(&key, STORAGE_TTL_THRESHOLD, STORAGE_TTL_LEDGERS);
 }
 
 pub fn get_open_bounties(env: &Env) -> Vec<BountyId> {


### PR DESCRIPTION
Closes #432

Adds `extend_ttl` calls to `get_approvals`/`set_approvals` in `src/storage.rs`, matching the pattern used by every other persistent key in the file. Without this, approval records for long-pending multi-sig bounties could expire and silently reset.

### Changes
- `src/storage.rs`: Added same `extend_ttl(&key, STORAGE_TTL_THRESHOLD, STORAGE_TTL_LEDGERS)` pattern used elsewhere