### PR TITLE
feat: add lightweight status-count query (Closes #443) [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/src/contract/queries.rs
+++ b/src/contract/queries.rs
@@ -35,4 +35,19 @@ impl MergeMintContract {
     pub fn get_bounties_by_creator(env: Env, creator: Address) -> Vec<BountyId> {
         storage::get_creator_bounties(&env, &creator)
     }
+
+    /// Return the number of bounties currently in the given status.
+    ///
+    /// This is a lightweight alternative to calling `get_bounties_by_status`
+    /// and measuring the length of the returned `Vec`. It reads a single
+    /// `u32` counter instead of the full status-index list, making it
+    /// suitable for dashboard badges, status-summary endpoints, and other
+    /// places where only the numeric count is needed.
+    ///
+    /// The counter is maintained automatically by `add_bounty_to_status`
+    /// and `remove_bounty_from_status` in the storage layer, so it always
+    /// reflects the current number of bounties in the requested status.
+    pub fn get_status_count(env: Env, status: Symbol) -> u32 {
+        storage::get_status_count(&env, &status)
+    }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -123,8 +123,10 @@ pub fn set_bounties_by_status(env: &Env, status: &Symbol, bounties: &Vec<BountyI
 
 pub fn add_bounty_to_status(env: &Env, bounty_id: &BountyId, status: &Symbol) {
     let mut current = get_bounties_by_status(env, status);
-    if current.iter().all(|id| id != *bounty_id) {
+    let is_new = current.iter().all(|id| id != *bounty_id);
+    if is_new {
         current.push_back(bounty_id.clone());
+        increment_status_count(env, status);
     }
     set_bounties_by_status(env, status, &current);
 }
@@ -132,10 +134,16 @@ pub fn add_bounty_to_status(env: &Env, bounty_id: &BountyId, status: &Symbol) {
 pub fn remove_bounty_from_status(env: &Env, bounty_id: &BountyId, status: &Symbol) {
     let current = get_bounties_by_status(env, status);
     let mut updated = Vec::new(env);
+    let mut removed = false;
     for id in current.iter() {
         if id != *bounty_id {
             updated.push_back(id);
+        } else {
+            removed = true;
         }
+    }
+    if removed {
+        decrement_status_count(env, status);
     }
     set_bounties_by_status(env, status, &updated);
 }
@@ -182,6 +190,35 @@ pub fn set_open_bounties(env: &Env, bounties: &Vec<BountyId>) {
     env.storage()
         .persistent()
         .extend_ttl(&key, STORAGE_TTL_THRESHOLD, STORAGE_TTL_LEDGERS);
+}
+
+// ── Status Count ─────────────────────────────────────────────────────────────
+
+pub fn get_status_count(env: &Env, status: &Symbol) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::StatusCount(status.clone()))
+        .unwrap_or(0)
+}
+
+fn increment_status_count(env: &Env, status: &Symbol) {
+    let count = get_status_count(env, status);
+    let key = DataKey::StatusCount(status.clone());
+    env.storage().persistent().set(&key, &(count + 1));
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, STORAGE_TTL_THRESHOLD, STORAGE_TTL_LEDGERS);
+}
+
+fn decrement_status_count(env: &Env, status: &Symbol) {
+    let count = get_status_count(env, status);
+    if count > 0 {
+        let key = DataKey::StatusCount(status.clone());
+        env.storage().persistent().set(&key, &(count - 1));
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, STORAGE_TTL_THRESHOLD, STORAGE_TTL_LEDGERS);
+    }
 }
 
 // ── Issue #3: Creator bounties index ─────────────────────────────────────────

--- a/src/test.rs
+++ b/src/test.rs
@@ -532,6 +532,79 @@ fn test_status_index_moves_on_cancel() {
 }
 
 // ===========================================================================
+// Status count (issue #443)
+// ===========================================================================
+
+/// get_status_count returns 0 for a status with no bounties.
+#[test]
+fn test_status_count_initial_zero() {
+    let (env, _creator, _contributor, _verifier) = setup_test();
+    let contract_id = env.register(MergeMintContract, ());
+    let client = MergeMintContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "open")), 0);
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "in_progress")), 0);
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "completed")), 0);
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "cancelled")), 0);
+}
+
+/// get_status_count returns 1 after creating a single bounty (open status).
+#[test]
+fn test_status_count_one_on_create() {
+    let (env, creator, _contributor, _verifier) = setup_test();
+    let contract_id = env.register(MergeMintContract, ());
+    let client = MergeMintContractClient::new(&env, &contract_id);
+
+    let _bounty_id = make_bounty(&client, &env, &creator, "count_one", None);
+
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "open")), 1);
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "cancelled")), 0);
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "completed")), 0);
+}
+
+/// get_status_count reflects the move from open to cancelled after cancel_bounty.
+#[test]
+fn test_status_count_moves_on_cancel() {
+    let (env, creator, _contributor, _verifier) = setup_test();
+    let contract_id = env.register(MergeMintContract, ());
+    let client = MergeMintContractClient::new(&env, &contract_id);
+
+    let bounty_id = make_bounty(&client, &env, &creator, "count_cancel", None);
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "open")), 1);
+
+    client.cancel_bounty(&creator, &bounty_id);
+
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "open")), 0);
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "cancelled")), 1);
+}
+
+/// get_status_count correctly tracks multiple bounties across statuses.
+#[test]
+fn test_status_count_multiple_bounties() {
+    let (env, creator, _contributor, verifier) = setup_test();
+    let contract_id = env.register(MergeMintContract, ());
+    let client = MergeMintContractClient::new(&env, &contract_id);
+
+    let id1 = make_bounty(&client, &env, &creator, "count_multi_a", None);
+    let id2 = make_bounty(&client, &env, &creator, "count_multi_b", None);
+    let _id3 = make_bounty(&client, &env, &creator, "count_multi_c", None);
+
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "open")), 3);
+
+    // Cancel one
+    client.cancel_bounty(&creator, &id1);
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "open")), 2);
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "cancelled")), 1);
+
+    // Claim one -> in_progress
+    let _token_addr = Address::generate(&env);
+    client.claim_bounty(&verifier, &id2);
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "open")), 1);
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "in_progress")), 1);
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "cancelled")), 1);
+}
+
+// ===========================================================================
 // Contributor metadata
 // ===========================================================================
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -31,6 +31,7 @@ pub enum DataKey {
     Contributor(Address),
     ContributorBounties(Address),
     StatusIndex(Symbol),
+    StatusCount(Symbol),
     OpenBounties,
     Approvals(BountyId),
 }


### PR DESCRIPTION
Closes #443

Adds `get_status_count(env, status: Symbol) -> u32` — a lightweight alternative to `get_bounties_by_status` that reads a single `u32` counter from persistent storage instead of pulling the full `Vec<BountyId>`.

**Changes:**
- `types.rs`: Add `DataKey::StatusCount(Symbol)` variant
- `storage.rs`: Add `get_status_count`, `increment_status_count`, `decrement_status_count` with TTL management
- `storage.rs`: Wire `add_bounty_to_status` / `remove_bounty_from_status` to update the counter on each status transition
- `queries.rs`: Expose `get_status_count` as a public contract query
- `test.rs`: 4 tests covering initial zero, single create, cancel move, and multi-bounty lifecycle

All 31 tests pass.