### PR TITLE
feat: add batch get_bounty_metas query for indexer efficiency [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/src/contract/queries.rs
+++ b/src/contract/queries.rs
@@ -11,6 +11,14 @@ impl MergeMintContract {
         storage::get_bounty_meta(&env, &bounty_id)
     }
 
+    pub fn get_bounty_metas(env: Env, ids: Vec<BountyId>) -> Vec<Option<BountyMeta>> {
+        let mut result: Vec<Option<BountyMeta>> = Vec::new(&env);
+        for id in ids.iter() {
+            result.push_back(storage::get_bounty_meta(&env, &id));
+        }
+        result
+    }
+
     pub fn get_contributor(env: Env, address: Address) -> Option<Contributor> {
         storage::get_contributor(&env, &address)
     }

--- a/src/test.rs
+++ b/src/test.rs
@@ -562,6 +562,53 @@ fn test_update_contributor_metadata_overwrites() {
 }
 
 // ===========================================================================
+// Batch query: get_bounty_metas
+// ===========================================================================
+
+/// Batch query returns correct metas for known IDs and None for unknown IDs.
+#[test]
+fn test_get_bounty_metas_batch() {
+    let (env, creator, _contributor, _verifier) = setup_test();
+    let contract_id = env.register(MergeMintContract, ());
+    let client = MergeMintContractClient::new(&env, &contract_id);
+
+    let id1 = make_bounty(&client, &env, &creator, "meta1", None);
+    let id2 = make_bounty(&client, &env, &creator, "meta2", None);
+
+    // Use a non-zero pattern for unknown IDs (see Bounty ID generation pitfall:
+    // the first bounty has count=0, producing all zeros)
+    let unknown_id = crate::types::BountyId(soroban_sdk::BytesN::from_array(
+        &env, &[0xffu8; 32],
+    ));
+
+    let mut ids: Vec<crate::types::BountyId> = Vec::new(&env);
+    ids.push_back(id1.clone());
+    ids.push_back(unknown_id.clone());
+    ids.push_back(id2.clone());
+
+    let results = client.get_bounty_metas(&ids);
+    assert_eq!(results.len(), 3);
+
+    // First result: known ID — should be Some
+    match results.get(0).unwrap() {
+        Some(meta) => assert_eq!(meta.title, Symbol::new(&env, "meta1")),
+        None => panic!("expected Some for known ID"),
+    }
+
+    // Second result: unknown ID — should be None
+    match results.get(1).unwrap() {
+        Some(_) => panic!("expected None for unknown ID"),
+        None => {} // expected
+    }
+
+    // Third result: known ID — should be Some
+    match results.get(2).unwrap() {
+        Some(meta) => assert_eq!(meta.title, Symbol::new(&env, "meta2")),
+        None => panic!("expected Some for known ID"),
+    }
+}
+
+// ===========================================================================
 // Security: double-completion guard
 // ===========================================================================
 


### PR DESCRIPTION
Closes #442

Adds `get_bounty_metas(env, ids: Vec<BountyId>) -> Vec<Option<BountyMeta>>` that accepts a vector of `BountyId` values and returns the meta for each one in order. Unknown IDs return `None` entries, allowing callers to batch multiple queries in a single contract call.

### Why this matters
The backend indexer currently makes one RPC call per bounty per poll to fetch title/description — a batch query cuts RPC round-trips significantly during backfill.

### Test Results
28 passed, 0 failed, including `test_get_bounty_metas_batch` which asserts `None` entries for unknown IDs interleaved with real ones.