### PR TITLE
fix: add client-side validation for bounty and profile forms

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@mergemint/app",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Frontend form components for the MergeMint bounty and contributor flows",
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "react": "^18.3.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/app/src/components/CharCounter.tsx
+++ b/app/src/components/CharCounter.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+interface CharCounterProps {
+  length: number;
+  max: number;
+}
+
+export function CharCounter({ length, max }: CharCounterProps) {
+  const overLimit = length > max;
+  return (
+    <span
+      className={overLimit ? "char-counter char-counter--over" : "char-counter"}
+    >
+      {length}/{max}
+    </span>
+  );
+}

--- a/app/src/components/ContributorProfile.tsx
+++ b/app/src/components/ContributorProfile.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from "react";
+import { CharCounter } from "./CharCounter";
+import { SYMBOL_MAX_LENGTH } from "../lib/validation";
+
+export interface ContributorProfileFormValues {
+  metadata: string;
+}
+
+interface ContributorProfileProps {
+  initialMetadata?: string;
+  onSave: (values: ContributorProfileFormValues) => void;
+}
+
+export function ContributorProfile({
+  initialMetadata = "",
+  onSave,
+}: ContributorProfileProps) {
+  const [metadata, setMetadata] = useState(initialMetadata);
+
+  const isOverLimit = metadata.length > SYMBOL_MAX_LENGTH;
+
+  function handleSave(event: React.FormEvent) {
+    event.preventDefault();
+    if (isOverLimit) return;
+    onSave({ metadata });
+  }
+
+  return (
+    <form onSubmit={handleSave} className="contributor-profile-form">
+      <label htmlFor="contributor-metadata">Metadata</label>
+      <input
+        id="contributor-metadata"
+        type="text"
+        value={metadata}
+        maxLength={SYMBOL_MAX_LENGTH}
+        onChange={(event) => setMetadata(event.target.value)}
+      />
+      <div className="field-footer">
+        <CharCounter length={metadata.length} max={SYMBOL_MAX_LENGTH} />
+        <span className="helper-text">
+          Stored on-chain as a Symbol, limited to {SYMBOL_MAX_LENGTH}{" "}
+          characters.
+        </span>
+      </div>
+      {isOverLimit && (
+        <span className="field-error">
+          Metadata exceeds the {SYMBOL_MAX_LENGTH}-character on-chain limit.
+        </span>
+      )}
+      <button type="submit" disabled={isOverLimit}>
+        Save
+      </button>
+    </form>
+  );
+}

--- a/app/src/components/CreateBounty.tsx
+++ b/app/src/components/CreateBounty.tsx
@@ -1,0 +1,113 @@
+import React, { useMemo, useState } from "react";
+import { CharCounter } from "./CharCounter";
+import {
+  SYMBOL_MAX_LENGTH,
+  isValidContractAddress,
+  isValidRewardAmount,
+} from "../lib/validation";
+
+export interface CreateBountyFormValues {
+  title: string;
+  description: string;
+  rewardAmount: string;
+  rewardToken: string;
+}
+
+interface CreateBountyProps {
+  onSubmit: (values: CreateBountyFormValues) => void;
+}
+
+export function CreateBounty({ onSubmit }: CreateBountyProps) {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [rewardAmount, setRewardAmount] = useState("");
+  const [rewardToken, setRewardToken] = useState("");
+
+  const rewardAmountError = useMemo(() => {
+    if (rewardAmount === "") return null;
+    return isValidRewardAmount(rewardAmount)
+      ? null
+      : "Enter a positive number with up to 7 decimal places.";
+  }, [rewardAmount]);
+
+  const rewardTokenError = useMemo(() => {
+    if (rewardToken === "") return null;
+    return isValidContractAddress(rewardToken)
+      ? null
+      : 'Enter a valid Soroban contract address (starts with "C", 56 characters).';
+  }, [rewardToken]);
+
+  const isFormValid =
+    title.trim() !== "" &&
+    description.trim() !== "" &&
+    isValidRewardAmount(rewardAmount) &&
+    isValidContractAddress(rewardToken);
+
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (!isFormValid) return;
+    onSubmit({ title, description, rewardAmount, rewardToken });
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="create-bounty-form">
+      <label htmlFor="bounty-title">Title</label>
+      <input
+        id="bounty-title"
+        type="text"
+        value={title}
+        maxLength={SYMBOL_MAX_LENGTH}
+        onChange={(event) => setTitle(event.target.value)}
+      />
+      <div className="field-footer">
+        <CharCounter length={title.length} max={SYMBOL_MAX_LENGTH} />
+        <span className="helper-text">
+          Stored on-chain as a Symbol, limited to {SYMBOL_MAX_LENGTH}{" "}
+          characters.
+        </span>
+      </div>
+
+      <label htmlFor="bounty-description">Description</label>
+      <textarea
+        id="bounty-description"
+        value={description}
+        maxLength={SYMBOL_MAX_LENGTH}
+        onChange={(event) => setDescription(event.target.value)}
+      />
+      <div className="field-footer">
+        <CharCounter length={description.length} max={SYMBOL_MAX_LENGTH} />
+        <span className="helper-text">
+          Stored on-chain as a Symbol, limited to {SYMBOL_MAX_LENGTH}{" "}
+          characters.
+        </span>
+      </div>
+
+      <label htmlFor="bounty-reward-amount">Reward Amount</label>
+      <input
+        id="bounty-reward-amount"
+        type="text"
+        inputMode="decimal"
+        value={rewardAmount}
+        onChange={(event) => setRewardAmount(event.target.value)}
+      />
+      {rewardAmountError && (
+        <span className="field-error">{rewardAmountError}</span>
+      )}
+
+      <label htmlFor="bounty-reward-token">Reward Token Address</label>
+      <input
+        id="bounty-reward-token"
+        type="text"
+        value={rewardToken}
+        onChange={(event) => setRewardToken(event.target.value)}
+      />
+      {rewardTokenError && (
+        <span className="field-error">{rewardTokenError}</span>
+      )}
+
+      <button type="submit" disabled={!isFormValid}>
+        Create Bounty
+      </button>
+    </form>
+  );
+}

--- a/app/src/lib/validation.ts
+++ b/app/src/lib/validation.ts
@@ -1,0 +1,18 @@
+// On-chain title/description/metadata fields are stored as Soroban Symbols,
+// which cap out at 32 characters.
+export const SYMBOL_MAX_LENGTH = 32;
+
+const REWARD_AMOUNT_REGEX = /^\d+(\.\d{1,7})?$/;
+
+export function isValidRewardAmount(value: string): boolean {
+  if (!REWARD_AMOUNT_REGEX.test(value.trim())) return false;
+  return parseFloat(value) > 0;
+}
+
+// Soroban contract addresses are strkey-encoded, start with "C", and are
+// always 56 characters long.
+const CONTRACT_ADDRESS_REGEX = /^C[A-Z2-7]{55}$/;
+
+export function isValidContractAddress(value: string): boolean {
+  return CONTRACT_ADDRESS_REGEX.test(value.trim());
+}

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM"],
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
Closes #497 
closes #498 
closes #499 
closes #500 

## Summary
- **#500** – Reward token address input now validates Soroban contract-address format (`C` prefix, 56 chars) before submission.
- **#499** – Reward amount input now requires a positive numeric value with up to 7 decimal places; submit is disabled until valid.
- **#498** – Title and description fields show a live `n/32` counter with helper text explaining the on-chain `Symbol` limit.
- **#497** – Contributor metadata field gets a `n/32` counter, helper text, and a pre-submit guard that disables Save above the limit.

No pre-existing frontend existed in this repo, so a minimal `app/` scaffold (`CreateBounty.tsx`, `ContributorProfile.tsx`, shared `CharCounter` + validation helpers) was added to host these fixes.

Tests skipped per task instructions.