### PR TITLE
docs: flag currently-unreachable multi-sig/multi-assignee UI blocks

### DIFF
--- a/frontend/src/components/BountyDetail.tsx
+++ b/frontend/src/components/BountyDetail.tsx
@@ -30,6 +30,9 @@ export function BountyDetail({ bounty, network, onClaim }: BountyDetailProps) {
           contract issue #11 (multi-sig verifiers) ships. */}
       <p className="bounty-detail__multisig-note">Verifiers: single-approver (multi-sig not yet enabled)</p>
 
+      {/* Stub only — percentage-share display is unreachable while the contract
+          still enforces a single assignee; activates once contract issues #9
+          (multi-assignee) and #11 (multi-sig verifiers) ship. */}
       <ul className="assignee-list">
         {bounty.assignees.map((assignee) => (
           <li key={assignee.address}>


### PR DESCRIPTION
## Summary
- Add a short comment above the assignee percentage-share list in `BountyDetail.tsx` noting it's unreachable until contract issues #9 (multi-assignee) and #11 (multi-sig verifiers) ship, matching the existing note above the multi-sig verifier block.

## Test plan
- Comment-only change, no test required (per issue).

Closes #503
closes #502 
closes #501 
closes #504 