### PR TITLE
fix: remove duplicate get_status_count definitions

### DIFF
--- a/src/contract/queries.rs
+++ b/src/contract/queries.rs
@@ -39,10 +39,6 @@ impl MergeMintContract {
         storage::get_bounties_by_status(&env, &status)
     }
 
-    pub fn get_status_count(env: Env, status: Symbol) -> u32 {
-        storage::get_status_count(&env, &status)
-    }
-
     pub fn get_open_bounties(env: Env) -> Vec<BountyId> {
         storage::get_open_bounties(&env)
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -231,13 +231,6 @@ pub fn set_open_bounties(env: &Env, bounties: &Vec<BountyId>) {
 
 // ── Status Count ─────────────────────────────────────────────────────────────
 
-pub fn get_status_count(env: &Env, status: &Symbol) -> u32 {
-    env.storage()
-        .persistent()
-        .get(&DataKey::StatusCount(status.clone()))
-        .unwrap_or(0)
-}
-
 fn increment_status_count(env: &Env, status: &Symbol) {
     let count = get_status_count(env, status);
     let key = DataKey::StatusCount(status.clone());


### PR DESCRIPTION
## Summary
- `main` currently fails to compile. `get_status_count` was defined twice in `src/storage.rs` (lines 131 and 234) and twice again as identical wrapper methods in `src/contract/queries.rs`, which the `#[contractimpl]` macro turns into E0428/E0034/E0592 duplicate-definition errors.
- Removes the redundant, less-consistent definition in each file (the ones without TTL-extension handling / the duplicate wrapper), keeping the version that matches this file's established pattern.

**Note for maintainers:** after this fix, `cargo build` still fails on 3 unrelated pre-existing errors that are out of scope for this PR:
- `complete_bounty_inner` is called from `approve_completion` (mutations.rs:340) but never defined.
- `ContractError::BountyNotDisputable` is referenced in `raise_dispute` (mutations.rs:400) but no such variant exists on the enum.
- `decrement_active_claims` is called in `resolve_dispute`'s "complete" branch (mutations.rs:468) but never defined.

These likely need a design decision (e.g. what `complete_bounty_inner` should share with `complete_bounty`) rather than a blind fix, so I left them for a follow-up.

## Validation
- `cargo build` — the `get_status_count` duplicate-definition errors are gone; only the 3 unrelated errors above remain.

closes #489 
closes #490 
closes #491 
closes #492 