### PR TITLE
fix: repair broken merge and CI-blocking bugs across contract + backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1540,9 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"

--- a/mergemint-backend/src/db.rs
+++ b/mergemint-backend/src/db.rs
@@ -51,7 +51,6 @@ mod tests {
     #[test]
     fn it_compiles() {}
 
-
     #[test]
     fn test_acquire_db_normal() {
         let db = new_shared_db();

--- a/mergemint-backend/src/main.rs
+++ b/mergemint-backend/src/main.rs
@@ -29,10 +29,7 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::{
-    routing::post,
-    Router,
-};
+use axum::{routing::post, Router};
 use tower_http::{
     limit::RequestBodyLimitLayer,
     request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer},
@@ -49,7 +46,7 @@ use db::new_shared_db;
 use routes::tx::{resolve_dispute, self_claim, AppState};
 
 /// Maximum allowed request body size (1 MiB).
-const MAX_BODY_BYTES: usize = 1 * 1024 * 1024;
+const MAX_BODY_BYTES: usize = 1024 * 1024;
 
 /// Maximum wall-clock time allowed for a single request, including body reads
 /// and handler execution.
@@ -74,7 +71,9 @@ async fn main() {
     tracing_subscriber::registry()
         .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| {
             // Default: info-level for our crate, warn for noisy deps.
-            "mergemint_backend=info,tower_http=debug,axum::rejection=trace".parse().unwrap()
+            "mergemint_backend=info,tower_http=debug,axum::rejection=trace"
+                .parse()
+                .unwrap()
         }))
         .with(fmt::layer())
         .init();
@@ -135,7 +134,5 @@ async fn main() {
         "mergemint-backend listening"
     );
 
-    axum::serve(listener, app)
-        .await
-        .expect("server error");
+    axum::serve(listener, app).await.expect("server error");
 }

--- a/mergemint-backend/src/test_helpers.rs
+++ b/mergemint-backend/src/test_helpers.rs
@@ -28,8 +28,6 @@
 // This module is compiled only when `cfg(test)` is active.  It is never
 // included in production binaries.
 
-#![cfg(test)]
-
 use crate::db::{new_shared_db, SharedDb};
 
 /// Return a fresh, empty [`SharedDb`] suitable for use in a single test.

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -1,4 +1,6 @@
-use soroban_sdk::{contract, contractimpl, token::TokenClient, Address, BytesN, Env, String, Symbol, Vec};
+use soroban_sdk::{
+    contract, contractimpl, token::TokenClient, Address, BytesN, Env, String, Symbol, Vec,
+};
 
 use crate::errors;
 use crate::errors::{fail, ContractError};

--- a/src/contract/mutations.rs
+++ b/src/contract/mutations.rs
@@ -103,6 +103,11 @@ impl MergeMintContract {
     /// * `deadline` - Optional ledger sequence deadline after which the bounty cannot be claimed.
     /// * `tags` - Categorisation tags (e.g. "bug", "docs"). At most 5 tags allowed.
     /// * `max_assignees` - Maximum number of contributors who can claim this bounty (must be >= 1).
+    /// * `required_verifiers` - Optional list of addresses permitted to approve completion via
+    ///   `approve_completion`. When `None`, the single-verifier `complete_bounty` flow applies.
+    /// * `approval_threshold` - Number of unique approvals required before completion executes
+    ///   automatically. Only meaningful when `required_verifiers` is `Some`; must not exceed the
+    ///   number of verifiers.
     ///
     /// # Returns
     /// The newly generated `BountyId` that uniquely identifies this bounty.
@@ -112,6 +117,8 @@ impl MergeMintContract {
     /// * If `reward_amount` is below `MIN_REWARD_AMOUNT` (`ContractError::RewardBelowMinimum`).
     /// * If `tags.len() > 5` (`ContractError::TooManyTags`).
     /// * If `max_assignees < 1` (`ContractError::MaxAssigneesMustBePositive`).
+    /// * If `approval_threshold` exceeds `required_verifiers.len()` when set
+    ///   (`ContractError::ApprovalThresholdExceedsVerifiers`).
     ///
     /// # Authorization
     /// Requires auth from `creator`.
@@ -126,11 +133,12 @@ impl MergeMintContract {
         deadline: Option<u32>,
         tags: Vec<Symbol>,
         max_assignees: u32,
+        required_verifiers: Option<Vec<Address>>,
+        approval_threshold: u32,
     ) -> BountyId {
-        // Validated first, ahead of auth and all storage interaction: a reward
-        // below the minimum threshold is a malformed request regardless of who
-        // is asking.
-        if reward_amount < MIN_REWARD_AMOUNT {
+        // Validated first, ahead of auth and all storage interaction: a
+        // non-positive reward is a malformed request regardless of who is asking.
+        if reward_amount <= 0 {
             fail(ContractError::RewardMustBePositive);
         }
 
@@ -141,6 +149,18 @@ impl MergeMintContract {
         // Validate tags length before auth to fail fast on malformed input.
         if tags.len() > 5 {
             fail(ContractError::TooManyTags);
+        }
+
+        // Validate max_assignees before auth: at least 1 is required.
+        if max_assignees < 1 {
+            fail(ContractError::MaxAssigneesMustBePositive);
+        }
+
+        // Validate multi-sig params: threshold must not exceed verifier count when set.
+        if let Some(ref verifiers) = required_verifiers {
+            if approval_threshold > verifiers.len() {
+                fail(ContractError::ApprovalThresholdExceedsVerifiers);
+            }
         }
 
         // Reject deadlines already in the past at creation time.
@@ -210,6 +230,11 @@ impl MergeMintContract {
             Some(b) => b,
             None => fail(ContractError::BountyNotFound),
         };
+
+        // GUARD: bounty must be in "open" status to be claimed.
+        if bounty.status != Symbol::new(&env, STATUS_OPEN) {
+            fail(ContractError::BountyNotOpen);
+        }
 
         // The creator of a bounty cannot claim their own bounty.
         if contributor == bounty.creator {

--- a/src/contract/queries.rs
+++ b/src/contract/queries.rs
@@ -44,6 +44,10 @@ impl MergeMintContract {
         storage::get_bounties_by_status(&env, &status)
     }
 
+    pub fn get_status_count(env: Env, status: Symbol) -> u32 {
+        storage::get_status_count(&env, &status)
+    }
+
     pub fn get_open_bounties(env: Env) -> Vec<BountyId> {
         storage::get_open_bounties(&env)
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -26,6 +26,7 @@ pub enum ContractError {
     AlreadyApproved,
     BountyNotDisputed,
     NotArbitrator,
+    ApprovalThresholdExceedsVerifiers,
 }
 
 /// Convert a `ContractError` to its canonical panic message and panic.
@@ -53,19 +54,16 @@ pub const fn message(e: ContractError) -> &'static str {
         ContractError::DeadlineNotPassed => "deadline has not passed",
         ContractError::ReputationTooLow => "contributor reputation is too low",
         ContractError::TooManyTags => "too many tags",
-        ContractError::MaxAssigneesMustBePositive => {
-            "max_assignees must be at least 1"
-        }
+        ContractError::MaxAssigneesMustBePositive => "max_assignees must be at least 1",
         ContractError::OnlyCreatorOrAssigneeCanDispute => {
             "only creator or assignee can raise dispute"
         }
-        ContractError::VerifierNotAuthorized => {
-            "verifier is not in the required verifiers list"
-        }
+        ContractError::VerifierNotAuthorized => "verifier is not in the required verifiers list",
         ContractError::AlreadyApproved => "verifier has already approved this bounty",
         ContractError::BountyNotDisputed => "bounty is not in disputed status",
-        ContractError::NotArbitrator => {
-            "caller is not authorized to resolve this dispute"
+        ContractError::NotArbitrator => "caller is not authorized to resolve this dispute",
+        ContractError::ApprovalThresholdExceedsVerifiers => {
+            "approval_threshold cannot exceed the number of required_verifiers"
         }
     }
 }

--- a/src/scval.rs
+++ b/src/scval.rs
@@ -178,13 +178,8 @@ mod tests {
         );
 
         // Decode
-        let (dec_addr, dec_rep, dec_earned, dec_contrib, dec_claims) = decode_contributor(
-            &enc_addr,
-            enc_rep,
-            enc_earned,
-            enc_contrib,
-            enc_claims,
-        );
+        let (dec_addr, dec_rep, dec_earned, dec_contrib, dec_claims) =
+            decode_contributor(&enc_addr, enc_rep, enc_earned, enc_contrib, enc_claims);
 
         // Verify round-trip
         assert_eq!(dec_addr, address);
@@ -232,7 +227,8 @@ mod tests {
         };
 
         // Encode the full bounty
-        let (enc_creator, enc_amount, enc_token, enc_assignees, enc_status) = encode_bounty(&bounty);
+        let (enc_creator, enc_amount, enc_token, enc_assignees, enc_status) =
+            encode_bounty(&bounty);
 
         // Verify encoded values match original
         assert_eq!(enc_creator, creator);
@@ -272,7 +268,8 @@ mod tests {
         };
 
         // Encode the full contributor
-        let (enc_addr, enc_rep, enc_earned, enc_contrib, enc_claims) = encode_contributor(&contributor);
+        let (enc_addr, enc_rep, enc_earned, enc_contrib, enc_claims) =
+            encode_contributor(&contributor);
 
         // Verify encoded values match original
         assert_eq!(enc_addr, address);
@@ -282,13 +279,8 @@ mod tests {
         assert_eq!(enc_claims, 3);
 
         // Verify round-trip
-        let (dec_addr, dec_rep, dec_earned, dec_contrib, dec_claims) = decode_contributor(
-            &enc_addr,
-            enc_rep,
-            enc_earned,
-            enc_contrib,
-            enc_claims,
-        );
+        let (dec_addr, dec_rep, dec_earned, dec_contrib, dec_claims) =
+            decode_contributor(&enc_addr, enc_rep, enc_earned, enc_contrib, enc_claims);
 
         assert_eq!(dec_addr, address);
         assert_eq!(dec_rep, 250);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -128,6 +128,17 @@ pub fn set_bounties_by_status(env: &Env, status: &Symbol, bounties: &Vec<BountyI
         .extend_ttl(&key, STORAGE_TTL_THRESHOLD, STORAGE_TTL_LEDGERS);
 }
 
+pub fn get_status_count(env: &Env, status: &Symbol) -> u32 {
+    let key = DataKey::StatusCount(status.clone());
+    let count: Option<u32> = env.storage().persistent().get(&key);
+    if count.is_some() {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, STORAGE_TTL_THRESHOLD, STORAGE_TTL_LEDGERS);
+    }
+    count.unwrap_or(0)
+}
+
 pub fn set_status_count(env: &Env, status: &Symbol, count: &u32) {
     let key = DataKey::StatusCount(status.clone());
     env.storage().persistent().set(&key, count);
@@ -141,6 +152,7 @@ pub fn add_bounty_to_status(env: &Env, bounty_id: &BountyId, status: &Symbol) {
     let is_new = current.iter().all(|id| id != *bounty_id);
     if is_new {
         current.push_back(bounty_id.clone());
+        set_bounties_by_status(env, status, &current);
         increment_status_count(env, status);
     }
 }
@@ -160,12 +172,6 @@ pub fn remove_bounty_from_status(env: &Env, bounty_id: &BountyId, status: &Symbo
         decrement_status_count(env, status);
     }
     set_bounties_by_status(env, status, &updated);
-    if updated.len() < current.len() {
-        let count = get_status_count(env, status);
-        if count > 0 {
-            set_status_count(env, status, &(count - 1));
-        }
-    }
 }
 
 pub fn move_bounty_status(

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: MIT
-#![cfg(test)]
 
 use soroban_sdk::{
     testutils::{Address as _, Ledger as _},
@@ -42,6 +41,8 @@ fn make_bounty(
         &deadline,
         &Vec::new(env),
         &1,
+        &None,
+        &1,
     )
 }
 
@@ -71,12 +72,15 @@ fn make_bounty_with_token(
     let bounty_id = client.create_bounty(
         creator,
         &Symbol::new(env, tag),
-        &Symbol::new(env, "desc"),
+        &String::from_str(env, "desc"),
         &reward_amount,
         &token_addr,
         &0,
         &deadline,
         &Vec::new(env),
+        &1,
+        &None,
+        &1,
     );
     (bounty_id, token_addr)
 }
@@ -106,6 +110,8 @@ fn test_tags_stored_and_retrieved() {
         &None,
         &tags,
         &1,
+        &None,
+        &1,
     );
 
     let bounty = client.get_bounty(&bounty_id).unwrap();
@@ -130,6 +136,8 @@ fn test_empty_tags_valid() {
         &0,
         &None,
         &Vec::new(&env),
+        &1,
+        &None,
         &1,
     );
 
@@ -161,6 +169,8 @@ fn test_five_tags_allowed() {
         &None,
         &tags,
         &1,
+        &None,
+        &1,
     );
 
     let bounty = client.get_bounty(&bounty_id).unwrap();
@@ -189,6 +199,8 @@ fn test_too_many_tags_panics() {
         &0,
         &None,
         &tags,
+        &1,
+        &None,
         &1,
     );
 }
@@ -402,12 +414,15 @@ fn test_create_bounty_rejects_past_deadline() {
     client.create_bounty(
         &creator,
         &Symbol::new(&env, "past_dl"),
-        &Symbol::new(&env, "desc"),
+        &String::from_str(&env, "desc"),
         &1000,
         &Address::generate(&env),
         &0,
         &Some(50),
         &Vec::new(&env),
+        &1,
+        &None,
+        &1,
     );
 }
 
@@ -422,12 +437,15 @@ fn test_create_bounty_accepts_future_deadline() {
     client.create_bounty(
         &creator,
         &Symbol::new(&env, "future_dl"),
-        &Symbol::new(&env, "desc"),
+        &String::from_str(&env, "desc"),
         &1000,
         &Address::generate(&env),
         &0,
         &Some(100),
         &Vec::new(&env),
+        &1,
+        &None,
+        &1,
     );
 }
 
@@ -453,6 +471,8 @@ fn test_create_bounty() {
         &None,
         &Vec::new(&env),
         &1,
+        &None,
+        &1,
     );
 
     let bounty = client.get_bounty(&bounty_id).unwrap();
@@ -462,10 +482,7 @@ fn test_create_bounty() {
 
     let meta = client.get_bounty_meta(&bounty_id).unwrap();
     assert_eq!(meta.title, Symbol::new(&env, "test_b"));
-    assert_eq!(
-        meta.description,
-        String::from_str(&env, "desc")
-    );
+    assert_eq!(meta.description, String::from_str(&env, "desc"));
 }
 
 // ===========================================================================
@@ -483,12 +500,15 @@ fn test_create_bounty_rejects_zero_reward() {
     client.create_bounty(
         &creator,
         &Symbol::new(&env, "zero_rew"),
-        &Symbol::new(&env, "desc"),
+        &String::from_str(&env, "desc"),
         &0,
         &Address::generate(&env),
         &0,
         &None,
         &Vec::new(&env),
+        &1,
+        &None,
+        &1,
     );
 }
 
@@ -503,18 +523,21 @@ fn test_create_bounty_rejects_negative_reward() {
     client.create_bounty(
         &creator,
         &Symbol::new(&env, "neg_rew"),
-        &Symbol::new(&env, "desc"),
+        &String::from_str(&env, "desc"),
         &(-50),
         &Address::generate(&env),
         &0,
         &None,
         &Vec::new(&env),
+        &1,
+        &None,
+        &1,
     );
 }
 
 /// Creating a bounty with reward_amount below MIN_REWARD_AMOUNT (100) must panic.
 #[test]
-#[should_panic(expected = "reward_amount must be positive")]
+#[should_panic(expected = "reward_amount is below the minimum allowed")]
 fn test_create_bounty_rejects_below_minimum_reward() {
     let (env, creator, _contributor, _verifier) = setup_test();
     let contract_id = env.register(MergeMintContract, ());
@@ -523,12 +546,15 @@ fn test_create_bounty_rejects_below_minimum_reward() {
     client.create_bounty(
         &creator,
         &Symbol::new(&env, "small_rew"),
-        &Symbol::new(&env, "desc"),
+        &String::from_str(&env, "desc"),
         &50,
         &Address::generate(&env),
         &0,
         &None,
         &Vec::new(&env),
+        &1,
+        &None,
+        &1,
     );
 }
 
@@ -547,6 +573,8 @@ fn test_claim_bounty() {
         &0,
         &None,
         &Vec::new(&env),
+        &1,
+        &None,
         &1,
     );
     client.claim_bounty(&contributor, &bounty_id);
@@ -567,12 +595,15 @@ fn test_creator_cannot_claim_own_bounty() {
     let bounty_id = client.create_bounty(
         &creator,
         &Symbol::new(&env, "bounty_1"),
-        &Symbol::new(&env, "desc"),
+        &String::from_str(&env, "desc"),
         &1000,
         &Address::generate(&env),
         &0,
         &None,
         &Vec::new(&env),
+        &1,
+        &None,
+        &1,
     );
     client.claim_bounty(&creator, &bounty_id);
 }
@@ -595,6 +626,8 @@ fn test_bounty_count() {
         &None,
         &Vec::new(&env),
         &1,
+        &None,
+        &1,
     );
     assert_eq!(client.get_bounty_count(), 1);
     client.create_bounty(
@@ -606,6 +639,8 @@ fn test_bounty_count() {
         &0,
         &None,
         &Vec::new(&env),
+        &1,
+        &None,
         &1,
     );
     assert_eq!(client.get_bounty_count(), 2);
@@ -761,12 +796,15 @@ fn test_claim_bounty_rejects_low_reputation() {
     client.create_bounty(
         &creator,
         &Symbol::new(&env, "rep_b"),
-        &Symbol::new(&env, "desc"),
+        &String::from_str(&env, "desc"),
         &1000,
         &Address::generate(&env),
         &10,
         &None,
         &Vec::new(&env),
+        &1,
+        &None,
+        &1,
     );
 
     let bounty_id = client.get_bounties_by_creator(&creator).get(0).unwrap();
@@ -829,7 +867,13 @@ fn test_status_index_moves_on_cancel() {
     let client = MergeMintContractClient::new(&env, &contract_id);
 
     let (bounty_id, _token_addr) = make_bounty_with_token(
-        &client, &env, &creator, &contract_id, "bounty_z", 1000, None,
+        &client,
+        &env,
+        &creator,
+        &contract_id,
+        "bounty_z",
+        1000,
+        None,
     );
     client.cancel_bounty(&creator, &bounty_id);
 
@@ -852,7 +896,10 @@ fn test_status_count_initial_zero() {
     let client = MergeMintContractClient::new(&env, &contract_id);
 
     assert_eq!(client.get_status_count(&Symbol::new(&env, "open")), 0);
-    assert_eq!(client.get_status_count(&Symbol::new(&env, "in_progress")), 0);
+    assert_eq!(
+        client.get_status_count(&Symbol::new(&env, "in_progress")),
+        0
+    );
     assert_eq!(client.get_status_count(&Symbol::new(&env, "completed")), 0);
     assert_eq!(client.get_status_count(&Symbol::new(&env, "cancelled")), 0);
 }
@@ -878,7 +925,15 @@ fn test_status_count_moves_on_cancel() {
     let contract_id = env.register(MergeMintContract, ());
     let client = MergeMintContractClient::new(&env, &contract_id);
 
-    let bounty_id = make_bounty(&client, &env, &creator, "count_cancel", None);
+    let (bounty_id, _token_addr) = make_bounty_with_token(
+        &client,
+        &env,
+        &creator,
+        &contract_id,
+        "count_cancel",
+        1000,
+        None,
+    );
     assert_eq!(client.get_status_count(&Symbol::new(&env, "open")), 1);
 
     client.cancel_bounty(&creator, &bounty_id);
@@ -894,7 +949,15 @@ fn test_status_count_multiple_bounties() {
     let contract_id = env.register(MergeMintContract, ());
     let client = MergeMintContractClient::new(&env, &contract_id);
 
-    let id1 = make_bounty(&client, &env, &creator, "count_multi_a", None);
+    let (id1, _id1_token) = make_bounty_with_token(
+        &client,
+        &env,
+        &creator,
+        &contract_id,
+        "count_multi_a",
+        1000,
+        None,
+    );
     let id2 = make_bounty(&client, &env, &creator, "count_multi_b", None);
     let _id3 = make_bounty(&client, &env, &creator, "count_multi_c", None);
 
@@ -909,7 +972,10 @@ fn test_status_count_multiple_bounties() {
     let _token_addr = Address::generate(&env);
     client.claim_bounty(&verifier, &id2);
     assert_eq!(client.get_status_count(&Symbol::new(&env, "open")), 1);
-    assert_eq!(client.get_status_count(&Symbol::new(&env, "in_progress")), 1);
+    assert_eq!(
+        client.get_status_count(&Symbol::new(&env, "in_progress")),
+        1
+    );
     assert_eq!(client.get_status_count(&Symbol::new(&env, "cancelled")), 1);
 }
 
@@ -959,9 +1025,7 @@ fn test_get_bounty_metas_batch() {
 
     // Use a non-zero pattern for unknown IDs (see Bounty ID generation pitfall:
     // the first bounty has count=0, producing all zeros)
-    let unknown_id = crate::types::BountyId(soroban_sdk::BytesN::from_array(
-        &env, &[0xffu8; 32],
-    ));
+    let unknown_id = crate::types::BountyId(soroban_sdk::BytesN::from_array(&env, &[0xffu8; 32]));
 
     let mut ids: Vec<crate::types::BountyId> = Vec::new(&env);
     ids.push_back(id1.clone());
@@ -978,10 +1042,10 @@ fn test_get_bounty_metas_batch() {
     }
 
     // Second result: unknown ID — should be None
-    match results.get(1).unwrap() {
-        Some(_) => panic!("expected None for unknown ID"),
-        None => {} // expected
-    }
+    assert!(
+        results.get(1).unwrap().is_none(),
+        "expected None for unknown ID"
+    );
 
     // Third result: known ID — should be Some
     match results.get(2).unwrap() {
@@ -1013,6 +1077,8 @@ fn test_double_complete_panics() {
         &None,
         &Vec::new(&env),
         &1,
+        &None,
+        &1,
     );
 
     // Bounty is "open", not "in_progress" — must panic.
@@ -1041,11 +1107,7 @@ fn test_status_count_open_on_create() {
 
     let open_count = client.get_status_count(&Symbol::new(&env, "open"));
     let open_ids = client.get_bounties_by_status(&Symbol::new(&env, "open"));
-    assert_eq!(
-        open_count,
-        open_ids.len() as u32,
-        "count matches index length"
-    );
+    assert_eq!(open_count, open_ids.len(), "count matches index length");
     assert_eq!(open_count, 1, "exactly one open bounty");
 }
 
@@ -1059,34 +1121,53 @@ fn test_status_count_across_transitions() {
     // Create: open=1, in_progress=0, cancelled=0
     let bounty_id = make_bounty(&client, &env, &creator, "sc_trans", None);
     assert_eq!(client.get_status_count(&Symbol::new(&env, "open")), 1);
-    assert_eq!(client.get_status_count(&Symbol::new(&env, "in_progress")), 0);
+    assert_eq!(
+        client.get_status_count(&Symbol::new(&env, "in_progress")),
+        0
+    );
     assert_eq!(client.get_status_count(&Symbol::new(&env, "cancelled")), 0);
 
     // Claim: open=0, in_progress=1
     client.claim_bounty(&contributor, &bounty_id);
     assert_eq!(client.get_status_count(&Symbol::new(&env, "open")), 0);
-    assert_eq!(client.get_status_count(&Symbol::new(&env, "in_progress")), 1);
     assert_eq!(
         client.get_status_count(&Symbol::new(&env, "in_progress")),
-        client.get_bounties_by_status(&Symbol::new(&env, "in_progress")).len() as u32,
+        1
+    );
+    assert_eq!(
+        client.get_status_count(&Symbol::new(&env, "in_progress")),
+        client
+            .get_bounties_by_status(&Symbol::new(&env, "in_progress"))
+            .len(),
     );
 
     // Cancel is only valid for open bounties, so create a second bounty
     // and cancel it directly: open=0→1, cancelled=0→1
-    let bounty_id2 = make_bounty(&client, &env, &creator, "sc_trans2", None);
+    let (bounty_id2, _bounty_id2_token) = make_bounty_with_token(
+        &client,
+        &env,
+        &creator,
+        &contract_id,
+        "sc_trans2",
+        1000,
+        None,
+    );
     assert_eq!(client.get_status_count(&Symbol::new(&env, "open")), 1);
     client.cancel_bounty(&creator, &bounty_id2);
     assert_eq!(client.get_status_count(&Symbol::new(&env, "open")), 0);
     assert_eq!(client.get_status_count(&Symbol::new(&env, "cancelled")), 1);
     assert_eq!(
         client.get_status_count(&Symbol::new(&env, "cancelled")),
-        client.get_bounties_by_status(&Symbol::new(&env, "cancelled")).len() as u32,
+        client
+            .get_bounties_by_status(&Symbol::new(&env, "cancelled"))
+            .len(),
     );
 }
 
-/// Multiple bounties in the same status are counted correctly.
+/// Multiple bounties in the same status are counted correctly, and the
+/// count matches the length of the status index.
 #[test]
-fn test_status_count_multiple_bounties() {
+fn test_status_count_matches_index_length() {
     let (env, creator, _contributor, _verifier) = setup_test();
     let contract_id = env.register(MergeMintContract, ());
     let client = MergeMintContractClient::new(&env, &contract_id);
@@ -1098,7 +1179,9 @@ fn test_status_count_multiple_bounties() {
     assert_eq!(client.get_status_count(&Symbol::new(&env, "open")), 3);
     assert_eq!(
         client.get_status_count(&Symbol::new(&env, "open")),
-        client.get_bounties_by_status(&Symbol::new(&env, "open")).len() as u32,
+        client
+            .get_bounties_by_status(&Symbol::new(&env, "open"))
+            .len(),
     );
 }
 
@@ -1119,6 +1202,8 @@ fn test_assignee_cannot_self_verify() {
         &0,
         &None,
         &Vec::new(&env),
+        &1,
+        &None,
         &1,
     );
 
@@ -1141,7 +1226,13 @@ fn test_cancel_bounty_refunds_escrow() {
 
     let reward_amount: i128 = 1000;
     let (bounty_id, token_addr) = make_bounty_with_token(
-        &client, &env, &creator, &contract_id, "refund_cancel", reward_amount, None,
+        &client,
+        &env,
+        &creator,
+        &contract_id,
+        "refund_cancel",
+        reward_amount,
+        None,
     );
 
     // Check contract balance before cancel.
@@ -1175,11 +1266,17 @@ fn test_expire_bounty_refunds_escrow() {
     let contract_id = env.register(MergeMintContract, ());
     let client = MergeMintContractClient::new(&env, &contract_id);
 
-    // Use deadline = 0 and set ledger sequence past it so the bounty is expired.
+    // Create with a deadline in the future, then advance the ledger past it
+    // so the bounty is expired without tripping the creation-time past-deadline guard.
     let reward_amount: i128 = 1000;
-    env.ledger().set_sequence_number(100);
     let (bounty_id, token_addr) = make_bounty_with_token(
-        &client, &env, &creator, &contract_id, "refund_expire", reward_amount, Some(0),
+        &client,
+        &env,
+        &creator,
+        &contract_id,
+        "refund_expire",
+        reward_amount,
+        Some(10),
     );
 
     let token_client = StellarAssetClient::new(&env, &token_addr);
@@ -1188,6 +1285,8 @@ fn test_expire_bounty_refunds_escrow() {
         reward_amount,
         "contract holds the escrowed reward before expire"
     );
+
+    env.ledger().set_sequence_number(100);
 
     // Any caller can trigger expiry.
     let caller = Address::generate(&env);
@@ -1214,7 +1313,13 @@ fn test_resolve_dispute_cancel_refunds_escrow() {
 
     let reward_amount: i128 = 1000;
     let (bounty_id, token_addr) = make_bounty_with_token(
-        &client, &env, &creator, &contract_id, "refund_disp", reward_amount, None,
+        &client,
+        &env,
+        &creator,
+        &contract_id,
+        "refund_disp",
+        reward_amount,
+        None,
     );
 
     client.claim_bounty(&contributor, &bounty_id);
@@ -1253,12 +1358,15 @@ fn test_resolve_dispute_complete_pays_from_arbitrator() {
     let bounty_id = client.create_bounty(
         &creator,
         &Symbol::new(&env, "resolve_complete"),
-        &Symbol::new(&env, "desc"),
+        &String::from_str(&env, "desc"),
         &reward_amount,
         &token_addr,
         &0,
         &None,
         &Vec::new(&env),
+        &1,
+        &None,
+        &1,
     );
 
     client.claim_bounty(&contributor, &bounty_id);


### PR DESCRIPTION
main was left non-compiling after PR #593's merge dropped the required_verifiers/approval_threshold params from create_bounty's signature while keeping body code (and the public get_status_count storage helper/endpoint) that referenced them — none of the CI jobs could even build.

Contract fixes:
- Restore create_bounty(required_verifiers, approval_threshold) params, ApprovalThresholdExceedsVerifiers error, and the max_assignees < 1 / reward_amount <= 0 checks that the merge conflict resolution dropped.
- Restore the claim_bounty "must be open" guard (#11) lost in the same merge.
- Restore storage::get_status_count and its public queries.rs endpoint, both silently deleted by an earlier "remove duplicate" fix.
- Fix add_bounty_to_status: it mutated a local copy of the status index but never persisted it, so get_bounties_by_status always returned empty.
- Fix remove_bounty_from_status double-decrementing the status counter (two independent decrement code paths had been merged together).
- Update all test.rs create_bounty call sites for the restored signature, fix description-type mismatches (Symbol vs String) left by a prior partial migration, dedupe two identically-named test functions, and adjust escrow-dependent tests to use real minted tokens instead of placeholder addresses now that cancel/expire refund escrow.
- cargo fmt + clippy -D warnings clean on both --all-targets and the lib-only invocation lint.yml uses.
- Bump the transitively-pinned `spin` dependency off a yanked version (0.9.8 -> 0.9.9) so cargo-audit passes.

Backend fixes:
- cargo fmt.
- Fix clippy: identity_op (1 * 1024 * 1024) and a duplicated #![cfg(test)] attribute on a module already gated by #[cfg(test)] in lib.rs.

Verified locally against every check each workflow in .github/workflows runs: fmt, clippy (both invocations), test, release build, wasm builds (wasm32v1-none and wasm32-unknown-unknown), and cargo audit.

## Summary of Changes

<!-- Describe what this PR changes and why. -->

## Related Issue

Closes #

## How to Test

<!-- Steps to verify this change works correctly. -->

1. 
2. 

## Screenshots / Output

<!-- Paste relevant command output, test results, or screenshots. -->

## Checklist

- [ ] Tests added or updated
- [ ] `cargo clippy` passes with no warnings
- [ ] `cargo fmt` applied
- [ ] PR description includes `Closes #<issue_id>`
