### PR TITLE
fix: repair CI breakage from PRs #595/#596 and a stale wasm target in…

### DIFF
--- a/.github/workflows/interface-check.yml
+++ b/.github/workflows/interface-check.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          targets: wasm32v1-none
 
       - uses: Swatinem/rust-cache@v2
 
@@ -22,10 +22,10 @@ jobs:
         run: cargo install stellar-cli
 
       - name: Build contract
-        run: cargo build --release --target wasm32-unknown-unknown
+        run: cargo build --release --target wasm32v1-none
 
       - name: Generate interface
-        run: stellar contract inspect target/wasm32-unknown-unknown/release/mergemint_contracts.wasm > current-interface.json
+        run: stellar contract inspect target/wasm32v1-none/release/mergemint_contracts.wasm > current-interface.json
         continue-on-error: true
 
       - name: Check interface baseline exists

--- a/mergemint-backend/src/routes/tx.rs
+++ b/mergemint-backend/src/routes/tx.rs
@@ -60,6 +60,12 @@ impl AppError {
     ///
     /// `detail` is **only** logged via `tracing::error!`; it is never
     /// included in the HTTP response body (see [`IntoResponse`] impl below).
+    ///
+    /// No handler in this stub backend currently produces a 500 (both
+    /// `resolve_dispute` and `self_claim` only ever return 400/404), so this
+    /// constructor has no live call site yet — it's exercised by the tests
+    /// below and is here for handlers that build real Horizon/RPC calls.
+    #[allow(dead_code)]
     pub fn internal(detail: impl std::fmt::Display) -> AppError {
         tracing::error!(detail = %detail, "internal server error");
         AppError {
@@ -242,8 +248,8 @@ pub async fn self_claim(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::response::IntoResponse;
     use axum::body::to_bytes;
+    use axum::response::IntoResponse;
 
     /// Helper: convert a Response body to a String.
     async fn body_string(response: axum::response::Response) -> String {

--- a/src/contract/mutations.rs
+++ b/src/contract/mutations.rs
@@ -231,8 +231,15 @@ impl MergeMintContract {
             None => fail(ContractError::BountyNotFound),
         };
 
-        // GUARD: bounty must be in "open" status to be claimed.
-        if bounty.status != Symbol::new(&env, STATUS_OPEN) {
+        // GUARD: a bounty in a terminal/blocked state can never be claimed.
+        // Note this is intentionally broader than `status == STATUS_OPEN`: a
+        // multi-assignee bounty moves to "in_progress" after its first claim
+        // and must remain claimable by further contributors while capacity
+        // remains (enforced below by the max_assignees check).
+        if bounty.status == Symbol::new(&env, STATUS_CANCELLED)
+            || bounty.status == Symbol::new(&env, STATUS_COMPLETED)
+            || bounty.status == Symbol::new(&env, STATUS_DISPUTED)
+        {
             fail(ContractError::BountyNotOpen);
         }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -727,7 +727,7 @@ fn test_second_claim_rejected_while_active() {
 }
 
 #[test]
-#[should_panic(expected = "bounty not open")]
+#[should_panic(expected = "bounty already assigned")]
 fn test_second_contributor_cannot_claim_full_bounty() {
     let (env, creator, contributor, _verifier) = setup_test();
     let contract_id = env.register(MergeMintContract, ());
@@ -1433,6 +1433,8 @@ fn make_multi_bounty_with_token(
         &None,
         &Vec::new(env),
         &max_assignees,
+        &None,
+        &1,
     );
     (bounty_id, token_addr)
 }
@@ -1449,7 +1451,13 @@ fn test_two_assignees_equal_share_bp() {
 
     let reward_amount: i128 = 10_000;
     let (bounty_id, _) = make_multi_bounty_with_token(
-        &client, &env, &creator, &verifier, "two_eq", reward_amount, 2,
+        &client,
+        &env,
+        &creator,
+        &verifier,
+        "two_eq",
+        reward_amount,
+        2,
     );
 
     // First claimant — absorbs remainder (10_000 % 2 == 0, so no remainder here).
@@ -1482,7 +1490,13 @@ fn test_two_assignees_payout_sum_equals_reward() {
 
     let reward_amount: i128 = 10_000;
     let (bounty_id, token_addr) = make_multi_bounty_with_token(
-        &client, &env, &creator, &verifier, "two_payout", reward_amount, 2,
+        &client,
+        &env,
+        &creator,
+        &verifier,
+        "two_payout",
+        reward_amount,
+        2,
     );
 
     client.claim_bounty(&contributor1, &bounty_id);
@@ -1518,7 +1532,13 @@ fn test_three_assignees_first_absorbs_remainder_share_bp() {
 
     let reward_amount: i128 = 10_000;
     let (bounty_id, _) = make_multi_bounty_with_token(
-        &client, &env, &creator, &verifier, "three_rem", reward_amount, 3,
+        &client,
+        &env,
+        &creator,
+        &verifier,
+        "three_rem",
+        reward_amount,
+        3,
     );
 
     client.claim_bounty(&contributor1, &bounty_id);
@@ -1565,7 +1585,13 @@ fn test_three_assignees_payout_sum_with_divisible_reward() {
     // 10_000 * 3334 / 10_000 = 3334 (exact), 10_000 * 3333 / 10_000 = 3333 (exact)
     let reward_amount: i128 = 10_000;
     let (bounty_id, token_addr) = make_multi_bounty_with_token(
-        &client, &env, &creator, &verifier, "three_div", reward_amount, 3,
+        &client,
+        &env,
+        &creator,
+        &verifier,
+        "three_div",
+        reward_amount,
+        3,
     );
 
     client.claim_bounty(&contributor1, &bounty_id);
@@ -1578,7 +1604,10 @@ fn test_three_assignees_payout_sum_with_divisible_reward() {
     let payout2 = token_client.balance(&contributor2);
     let payout3 = token_client.balance(&contributor3);
 
-    assert_eq!(payout1, 3_334, "first assignee payout (with remainder share)");
+    assert_eq!(
+        payout1, 3_334,
+        "first assignee payout (with remainder share)"
+    );
     assert_eq!(payout2, 3_333, "second assignee payout");
     assert_eq!(payout3, 3_333, "third assignee payout");
     assert_eq!(
@@ -1610,7 +1639,13 @@ fn test_three_assignees_payout_integer_division_loss_documented() {
     // Use 9_999 — not perfectly divisible by 3_333/3_334 in the payout formula.
     let reward_amount: i128 = 9_999;
     let (bounty_id, token_addr) = make_multi_bounty_with_token(
-        &client, &env, &creator, &verifier, "three_loss", reward_amount, 3,
+        &client,
+        &env,
+        &creator,
+        &verifier,
+        "three_loss",
+        reward_amount,
+        3,
     );
 
     client.claim_bounty(&contributor1, &bounty_id);
@@ -1623,20 +1658,19 @@ fn test_three_assignees_payout_integer_division_loss_documented() {
     let payout2 = token_client.balance(&contributor2);
     let payout3 = token_client.balance(&contributor3);
 
-    // 9_999 * 3_334 / 10_000 = 3_332 (truncated from 3_332.6666)
-    assert_eq!(payout1, 3_332, "first assignee payout (truncated)");
-    // 9_999 * 3_333 / 10_000 = 3_332 (truncated from 3_332.3667)
+    // 9_999 * 3_334 / 10_000 = 3_333 (truncated from 3_333.6666)
+    assert_eq!(payout1, 3_333, "first assignee payout (truncated)");
+    // 9_999 * 3_333 / 10_000 = 3_332 (truncated from 3_332.6667)
     assert_eq!(payout2, 3_332, "second assignee payout (truncated)");
     assert_eq!(payout3, 3_332, "third assignee payout (truncated)");
 
     let total_paid = payout1 + payout2 + payout3;
     let integer_division_loss = reward_amount - total_paid;
 
-    // Document the known loss: 9_999 - 9_996 = 3 tokens unaccounted for.
+    // Document the known loss: 9_999 - 9_997 = 2 tokens unaccounted for.
     assert_eq!(
-        integer_division_loss,
-        3,
-        "integer-division loss is 3 tokens for reward_amount=9_999 with 3 assignees"
+        integer_division_loss, 2,
+        "integer-division loss is 2 tokens for reward_amount=9_999 with 3 assignees"
     );
     // The total paid is strictly less than reward_amount in this case.
     assert!(
@@ -1658,7 +1692,13 @@ fn test_two_assignees_uneven_reward_integer_division_loss() {
 
     let reward_amount: i128 = 9_999;
     let (bounty_id, token_addr) = make_multi_bounty_with_token(
-        &client, &env, &creator, &verifier, "two_odd", reward_amount, 2,
+        &client,
+        &env,
+        &creator,
+        &verifier,
+        "two_odd",
+        reward_amount,
+        2,
     );
 
     client.claim_bounty(&contributor1, &bounty_id);
@@ -1678,8 +1718,7 @@ fn test_two_assignees_uneven_reward_integer_division_loss() {
 
     // Document: 1 token lost.
     assert_eq!(
-        integer_division_loss,
-        1,
+        integer_division_loss, 1,
         "integer-division loss is 1 token for reward_amount=9_999 with 2 assignees"
     );
 }


### PR DESCRIPTION
… interface-check.yml

Both PRs merged cleanly but were written against a stale main (before #597 fixed create_bounty's signature), and PR #596's own test additions had bugs of their own:

- Root Lint / Backend CI: cargo fmt drift in both crates (unformatted test.rs additions from #596, unformatted routes/tx.rs from #595).
- test.rs: make_multi_bounty_with_token (added by #596) called create_bounty with the pre-#597 8-arg signature, missing required_verifiers/approval_threshold.
- claim_bounty: the "must be open" guard added by #597 was too strict — it blocked every claim after the first on a multi-assignee bounty, since status flips to "in_progress" on the first claim regardless of remaining capacity. Narrowed the guard to reject only terminal states (cancelled/completed/disputed); the existing max_assignees capacity check already gates further claims correctly.
- test.rs: fixed test_second_contributor_cannot_claim_full_bounty's should_panic message, corrupted to "bounty not open" by an earlier bad merge — the capacity-check panic has always been "bounty already assigned" (confirmed against the commit that introduced the test).
- test.rs: fixed an arithmetic error in #596's own test_three_assignees_payout_integer_division_loss_documented — with share_bp 3334/3333/3333 and reward_amount=9999, the first assignee's truncated payout is 3333 (not 3332) and the aggregate integer-division loss is 2 tokens (not 3); verified independently in Python.
- mergemint-backend: fixed clippy identity_op (1 * 1024 * 1024) and a dead_code lint on AppError::internal, which #595 added as a security utility but never wired into a live handler (both existing handlers only ever return 400/404) — allow(dead_code) with a note, since it's covered by tests and is there for future handlers that need it.
- .github/workflows/interface-check.yml: switched the build target from wasm32-unknown-unknown to wasm32v1-none. soroban-sdk 27.x hard-rejects wasm32-unknown-unknown on Rust 1.82+, so this job's "Build contract" step always fails without continue-on-error. It doesn't block main (pull_request-only trigger) but would break on every future PR; build.yml already uses the correct target.

Verified locally: fmt + clippy -D warnings clean on both crates, 63/63 root tests pass, 10/10 backend tests pass, release + both wasm builds succeed, cargo audit clean.

## Summary of Changes

<!-- Describe what this PR changes and why. -->

## Related Issue

Closes #

## How to Test

<!-- Steps to verify this change works correctly. -->

1. 
2. 

## Screenshots / Output

<!-- Paste relevant command output, test results, or screenshots. -->

## Checklist

- [ ] Tests added or updated
- [ ] `cargo clippy` passes with no warnings
- [ ] `cargo fmt` applied
- [ ] PR description includes `Closes #<issue_id>`
