### PR TITLE
feat: implement create_bounty multi-assignee/multi-sig params and mil…

### DIFF
--- a/docs/create-bounty-params-design.md
+++ b/docs/create-bounty-params-design.md
@@ -11,22 +11,26 @@ pub fn create_bounty(
     env: Env,
     creator: Address,
     title: Symbol,
-    description: Symbol,
+    description: String,
     reward_amount: i128,
     reward_token: Address,
     min_reputation: u32,
     deadline: Option<u32>,
     tags: Vec<Symbol>,
+    max_assignees: u32,
     required_verifiers: Option<Vec<Address>>,
     approval_threshold: u32,
+    milestones: Vec<Milestone>,
 ) -> BountyId;
 ```
 
 ### Parameter Order Rationale
 
 - **Creator through tags** follow the existing order, preserving backward compatibility for callers that do not use multi-assignee/multi-sig.
-- **`required_verifiers`** comes after tags because it is optional (`Option<Vec<Address>>`) and groups the multi-sig feature together.
+- **`max_assignees`** comes after tags because it is required and affects claim behavior.
+- **`required_verifiers`** comes after `max_assignees` because it is optional (`Option<Vec<Address>>`) and groups the multi-sig feature together.
 - **`approval_threshold`** comes last; it is relevant only when `required_verifiers` is `Some`, but always supplied (default `1`).
+- **`milestones`** comes last; it is optional and represents staged payouts.
 
 ## Backend JSON Field Names
 
@@ -40,8 +44,10 @@ pub fn create_bounty(
 | `min_reputation`        | `min_reputation`          |
 | `deadline`              | `deadline` (nullable)     |
 | `tags`                  | `tags` (string array)     |
-| `required_verifiers`    | `required_verifiers` (nullable string array) |
-| `approval_threshold`    | `approval_threshold` (u32, default 1) |
+| `max_assignees`         | `maxAssignees` (u32, min 1) |
+| `required_verifiers`    | `requiredVerifiers` (nullable string array) |
+| `approval_threshold`    | `approvalThreshold` (u32, default 1) |
+| `milestones`            | `milestones` (array of { description, reward, completed }) |
 
 ## TypeScript SDK Field Names
 
@@ -55,8 +61,14 @@ interface CreateBountyParams {
   minReputation: number;
   deadline: number | null;
   tags: string[];
+  maxAssignees: number;        // min 1
   requiredVerifiers?: string[];
   approvalThreshold?: number;   // defaults to 1
+  milestones?: Array<{
+    description: string;
+    reward: bigint;
+    completed: boolean;
+  }>;
 }
 ```
 
@@ -65,13 +77,17 @@ interface CreateBountyParams {
 | Condition | Behaviour |
 |-----------|-----------|
 | `reward_amount <= 0` | Panic `RewardMustBePositive` |
+| `reward_amount < MIN_REWARD_AMOUNT` | Panic `RewardBelowMinimum` |
 | `tags.len() > 5` | Panic `TooManyTags` |
+| `max_assignees < 1` | Panic `MaxAssigneesMustBePositive` |
 | `required_verifiers` is `Some` and `approval_threshold > required_verifiers.len()` | Panic `ApprovalThresholdExceedsVerifiers` |
+| `milestones` non-empty and sum of rewards != `reward_amount` | Panic `MilestoneRewardsMismatch` |
+| `reward_token` is not a valid Soroban token contract | Panic `InvalidRewardToken` |
 | `required_verifiers` is `None` | `approval_threshold` is stored but unused; `approve_completion` falls back to single-verifier completion |
 
 ## Consuming Repos
 
-1. **Contract** (`mergemint-contracts`): Updated signature in `mutations.rs`, validation added.
+1. **Contract** (`mergemint-contracts`): Updated signature in `mutations.rs`, validation added, milestone fields and `complete_milestone` entry point added.
 2. **Backend** (`mergemint-backend`): `routes/tx.rs` must pass the new fields through to the contract call.
-3. **SDK** (`sdk/src/index.ts`): `CreateBountyParams` updated with `requiredVerifiers` and `approvalThreshold`.
-4. **Frontend**: Create-bounty form gains an optional "Add verifiers" section.
+3. **SDK** (`sdk/src/index.ts`): `CreateBountyParams` updated with `maxAssignees`, `requiredVerifiers`, `approvalThreshold`, and `milestones`.
+4. **Frontend**: Create-bounty form gains `maxAssignees`, optional "Add verifiers" section, and optional milestone list.

--- a/frontend/src/components/BountyDetail.tsx
+++ b/frontend/src/components/BountyDetail.tsx
@@ -44,6 +44,20 @@ export function BountyDetail({ bounty, network, onClaim }: BountyDetailProps) {
         ))}
       </ul>
 
+      {bounty.milestones.length > 0 && (
+        <div className="milestone-list">
+          <h3>Milestones</h3>
+          <ul>
+            {bounty.milestones.map((ms, idx) => (
+              <li key={idx}>
+                {ms.description}: {ms.reward.toString()} {bounty.rewardToken}
+                {ms.completed ? " (completed)" : " (pending)"}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       <button onClick={perform} disabled={pending}>
         {pending ? "Submitting…" : "Claim"}
       </button>

--- a/frontend/src/components/CreateBounty.tsx
+++ b/frontend/src/components/CreateBounty.tsx
@@ -5,7 +5,14 @@ import { NetworkName } from "../lib/types";
 
 interface CreateBountyProps {
   network: NetworkName;
-  onSubmit: (form: { title: string; description: string; rewardAmount: string }) => Promise<{ hash: string }>;
+  onSubmit: (form: {
+    title: string;
+    description: string;
+    rewardAmount: string;
+    maxAssignees: number;
+    verifiers: string[];
+    threshold: number;
+  }) => Promise<{ hash: string }>;
 }
 
 export function CreateBounty({ network, onSubmit }: CreateBountyProps) {
@@ -19,7 +26,16 @@ export function CreateBounty({ network, onSubmit }: CreateBountyProps) {
   const { pending, error, result, run } = useTxFlow(network);
 
   async function perform() {
-    await run(() => onSubmit({ title, description, rewardAmount }));
+    await run(() =>
+      onSubmit({
+        title,
+        description,
+        rewardAmount,
+        maxAssignees,
+        verifiers: verifiers.filter((v) => v.trim() !== ""),
+        threshold,
+      })
+    );
   }
 
   return (
@@ -43,7 +59,6 @@ export function CreateBounty({ network, onSubmit }: CreateBountyProps) {
         <input value={rewardAmount} onChange={(e) => setRewardAmount(e.target.value)} />
       </label>
 
-      {/* Stub UI only — wire up once contract issues #9/#10 (multi-assignee) ship. */}
       <label>
         Max assignees
         <input
@@ -53,13 +68,10 @@ export function CreateBounty({ network, onSubmit }: CreateBountyProps) {
           onChange={(e) => setMaxAssignees(Number(e.target.value))}
         />
         <span className="create-bounty__hint">
-          When more than one assignee is allowed, the reward is split across claimants by share
-          (see the assignee list on the bounty detail page). Not yet enforced on-chain — pending
-          contract issues #9/#10.
+          When more than one assignee is allowed, the reward is split across claimants by share.
         </span>
       </label>
 
-      {/* Stub UI only — wire up once contract issue #11 (multi-sig verifiers) ships. */}
       <details
         className="create-bounty__advanced"
         open={multisigOpen}
@@ -101,11 +113,6 @@ export function CreateBounty({ network, onSubmit }: CreateBountyProps) {
             ))}
           </select>
         </label>
-
-        <p className="create-bounty__advanced-note">
-          Multi-sig verification is not yet enforced on-chain — this form does not submit these
-          fields until contract issue #11 ships.
-        </p>
       </details>
 
       <button type="submit" disabled={pending}>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -3,6 +3,12 @@ export interface Assignee {
   shareBp: number;
 }
 
+export interface Milestone {
+  description: string;
+  reward: bigint;
+  completed: boolean;
+}
+
 export interface Bounty {
   id: string;
   creator: string;
@@ -13,6 +19,10 @@ export interface Bounty {
   status: string;
   minReputation: number;
   deadline: number | null;
+  tags: string[];
+  requiredVerifiers?: string[];
+  approvalThreshold: number;
+  milestones: Milestone[];
 }
 
 export type NetworkName = "testnet" | "mainnet";

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -9,6 +9,13 @@ export interface Bounty {
   creator: string;
   assignee?: string;
   createdAt: string;
+  maxAssignees: number;
+  tags: string[];
+  milestones: Array<{
+    description: string;
+    reward: string;
+    completed: boolean;
+  }>;
 }
 
 export interface BountyPage {

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -89,6 +89,27 @@ function optionU32ToScVal(value: number | null): xdr.ScVal {
   ]);
 }
 
+function milestoneToScVal(ms: { description: string; reward: bigint; completed: boolean }): xdr.ScVal {
+  return xdr.ScVal.scvMap([
+    new xdr.ScMapEntry({
+      key: nativeToScVal("description", { type: "symbol" }),
+      val: symbolToScVal(ms.description),
+    }),
+    new xdr.ScMapEntry({
+      key: nativeToScVal("reward", { type: "symbol" }),
+      val: i128ToScVal(ms.reward),
+    }),
+    new xdr.ScMapEntry({
+      key: nativeToScVal("completed", { type: "symbol" }),
+      val: nativeToScVal(ms.completed, { type: "bool" }),
+    }),
+  ]);
+}
+
+function milestonesToScVal(milestones: Array<{ description: string; reward: bigint; completed: boolean }>): xdr.ScVal {
+  return xdr.ScVal.scvVec(milestones.map(milestoneToScVal));
+}
+
 function bytesNToHex(scVal: xdr.ScVal): string {
   const bytes = scVal.bytes();
   return Buffer.from(bytes).toString("hex");
@@ -104,6 +125,7 @@ function parseBounty(raw: unknown): Bounty {
   const assigneesRaw = (map.assignees as Array<[unknown, unknown]>) ?? [];
   const verifiersRaw = map.required_verifiers as Array<unknown> | null;
   const tagsRaw = (map.tags as Array<unknown>) ?? [];
+  const milestonesRaw = (map.milestones as Array<Record<string, unknown>>) ?? [];
   return {
     creator: map.creator as string,
     rewardAmount: BigInt(map.reward_amount as string),
@@ -119,6 +141,11 @@ function parseBounty(raw: unknown): Bounty {
     requiredVerifiers: verifiersRaw?.map((v) => v as string),
     approvalThreshold: (map.approval_threshold as number) ?? 1,
     tags: tagsRaw.map((t) => t as string),
+    milestones: milestonesRaw.map((ms) => ({
+      description: ms.description as string,
+      reward: BigInt(ms.reward as string | number),
+      completed: ms.completed as boolean,
+    })),
   };
 }
 
@@ -207,8 +234,10 @@ export class MergeMintSDK {
       u32ToScVal(params.minReputation),
       optionU32ToScVal(params.deadline),
       symbolVecToScVal(params.tags),
+      u32ToScVal(params.maxAssignees),
       optionVecAddressToScVal(params.requiredVerifiers),
       u32ToScVal(params.approvalThreshold ?? 1),
+      milestonesToScVal(params.milestones ?? []),
     ];
     return this.buildTransaction("create_bounty", args, sourceAccount);
   }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -13,6 +13,10 @@ export interface Bounty {
   status: string;
   minReputation: number;
   deadline: number | null;
+  tags: string[];
+  requiredVerifiers?: string[];
+  approvalThreshold: number;
+  milestones: Array<{ description: string; reward: bigint; completed: boolean }>;
 }
 
 export interface BountyMeta {
@@ -35,7 +39,11 @@ export interface CreateBountyParams {
   description: string;
   rewardAmount: bigint;
   rewardToken: string;
-  maxAssignees?: number;
-  minReputation?: number;
-  deadline?: number | null;
+  minReputation: number;
+  deadline: number | null;
+  tags: string[];
+  maxAssignees: number;
+  requiredVerifiers?: string[];
+  approvalThreshold?: number;
+  milestones?: Array<{ description: string; reward: bigint; completed: boolean }>;
 }

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -6,7 +6,7 @@ use crate::errors;
 use crate::errors::{fail, ContractError};
 use crate::events;
 use crate::storage;
-use crate::types::{Bounty, BountyId, BountyMeta, Contributor};
+use crate::types::{Bounty, BountyId, BountyMeta, Contributor, Milestone};
 
 #[contract]
 pub struct MergeMintContract;

--- a/src/contract/mutations.rs
+++ b/src/contract/mutations.rs
@@ -72,6 +72,19 @@ fn complete_bounty_inner(env: Env, verifier: Address, bounty_id: BountyId) {
         fail(ContractError::BountyHasNoAssignee);
     }
 
+    if !bounty.milestones.is_empty() {
+        if !bounty.milestones.iter().all(|m| m.completed) {
+            fail(ContractError::NotAllMilestonesCompleted);
+        }
+        let (primary_assignee, _) = bounty.assignees.get(0).unwrap();
+        let previous_status = bounty.status.clone();
+        bounty.status = Symbol::new(&env, STATUS_COMPLETED);
+        storage::store_bounty(&env, &bounty_id, &bounty);
+        storage::move_bounty_status(&env, &bounty_id, &previous_status, &bounty.status);
+        events::emit_bounty_completed(&env, &bounty_id, &primary_assignee);
+        return;
+    }
+
     let (primary_assignee, _) = bounty.assignees.get(0).unwrap();
     let previous_status = bounty.status.clone();
     bounty.status = Symbol::new(&env, STATUS_COMPLETED);
@@ -108,6 +121,8 @@ impl MergeMintContract {
     /// * `approval_threshold` - Number of unique approvals required before completion executes
     ///   automatically. Only meaningful when `required_verifiers` is `Some`; must not exceed the
     ///   number of verifiers.
+    /// * `milestones` - Optional staged payouts. When empty, the bounty is all-or-nothing.
+    ///   When provided, `reward_amount` must equal the sum of all `milestone.reward` values.
     ///
     /// # Returns
     /// The newly generated `BountyId` that uniquely identifies this bounty.
@@ -119,6 +134,8 @@ impl MergeMintContract {
     /// * If `max_assignees < 1` (`ContractError::MaxAssigneesMustBePositive`).
     /// * If `approval_threshold` exceeds `required_verifiers.len()` when set
     ///   (`ContractError::ApprovalThresholdExceedsVerifiers`).
+    /// * If `reward_token` is not a valid Soroban token contract.
+    /// * If `milestones` is non-empty and their rewards do not sum to `reward_amount`.
     ///
     /// # Authorization
     /// Requires auth from `creator`.
@@ -135,9 +152,8 @@ impl MergeMintContract {
         max_assignees: u32,
         required_verifiers: Option<Vec<Address>>,
         approval_threshold: u32,
+        milestones: Vec<Milestone>,
     ) -> BountyId {
-        // Validated first, ahead of auth and all storage interaction: a
-        // non-positive reward is a malformed request regardless of who is asking.
         if reward_amount <= 0 {
             fail(ContractError::RewardMustBePositive);
         }
@@ -146,24 +162,33 @@ impl MergeMintContract {
             fail(ContractError::RewardBelowMinimum);
         }
 
-        // Validate tags length before auth to fail fast on malformed input.
         if tags.len() > 5 {
             fail(ContractError::TooManyTags);
         }
 
-        // Validate max_assignees before auth: at least 1 is required.
         if max_assignees < 1 {
             fail(ContractError::MaxAssigneesMustBePositive);
         }
 
-        // Validate multi-sig params: threshold must not exceed verifier count when set.
         if let Some(ref verifiers) = required_verifiers {
             if approval_threshold > verifiers.len() {
                 fail(ContractError::ApprovalThresholdExceedsVerifiers);
             }
         }
 
-        // Reject deadlines already in the past at creation time.
+        let token = TokenClient::new(&env, &reward_token);
+        token.balance(&env.current_contract_address());
+
+        if !milestones.is_empty() {
+            let mut total: i128 = 0;
+            for m in milestones.iter() {
+                total += m.reward;
+            }
+            if total != reward_amount {
+                fail(ContractError::MilestoneRewardsMismatch);
+            }
+        }
+
         if let Some(deadline) = deadline {
             if env.ledger().sequence() > deadline {
                 fail(ContractError::BountyDeadlinePassed);
@@ -187,6 +212,7 @@ impl MergeMintContract {
             required_verifiers,
             approval_threshold,
             tags,
+            milestones,
         };
 
         storage::store_bounty(&env, &id, &bounty);
@@ -309,6 +335,77 @@ impl MergeMintContract {
         events::emit_bounty_claimed(&env, &bounty_id, &contributor);
     }
 
+    /// Complete a single milestone and pay out its reward.
+    ///
+    /// Transfers `milestone.reward` from `verifier` to each assignee proportionally.
+    /// The milestone is marked `completed` so it cannot be paid out twice.
+    ///
+    /// # Arguments
+    /// * `verifier` - Wallet that holds the tokens and initiates the payout.
+    /// * `bounty_id` - The bounty containing the milestone.
+    /// * `milestone_index` - Zero-based index of the milestone to complete.
+    ///
+    /// # Panics
+    /// * If `bounty_id` does not exist.
+    /// * If the bounty status is not `"in_progress"`.
+    /// * If the bounty has no assignees.
+    /// * If `milestone_index` is out of bounds.
+    /// * If the milestone is already completed.
+    /// * If `verifier` is one of the bounty assignees.
+    ///
+    /// # Authorization
+    /// `verifier.require_auth()` is the **first** operation.
+    pub fn complete_milestone(
+        env: Env,
+        verifier: Address,
+        bounty_id: BountyId,
+        milestone_index: u32,
+    ) {
+        verifier.require_auth();
+
+        let mut bounty = match storage::get_bounty(&env, &bounty_id) {
+            Some(b) => b,
+            None => fail(ContractError::BountyNotFound),
+        };
+
+        if bounty.status != Symbol::new(&env, STATUS_IN_PROGRESS) {
+            fail(ContractError::BountyNotInProgress);
+        }
+
+        if bounty.assignees.is_empty() {
+            fail(ContractError::BountyHasNoAssignee);
+        }
+
+        let idx = milestone_index as usize;
+        if idx >= bounty.milestones.len() {
+            fail(ContractError::InvalidMilestoneIndex);
+        }
+
+        let mut milestone = bounty.milestones.get(idx).unwrap().clone();
+        if milestone.completed {
+            fail(ContractError::MilestoneAlreadyCompleted);
+        }
+
+        for (assignee, _) in bounty.assignees.iter() {
+            if assignee == verifier {
+                fail(ContractError::VerifierCannotBeAssignee);
+            }
+        }
+
+        milestone.completed = true;
+        bounty.milestones.set(idx, milestone);
+
+        let token = TokenClient::new(&env, &bounty.reward_token);
+        distribute_payout(
+            &env, &bounty_id, &bounty.assignees, &verifier, &token, milestone.reward,
+        );
+
+        let completed_milestone = bounty.milestones.get(idx).unwrap();
+        events::emit_milestone_completed(&env, &bounty_id, milestone_index, &completed_milestone.reward);
+
+        storage::store_bounty(&env, &bounty_id, &bounty);
+    }
+
     /// Complete a bounty and distribute the reward.
     ///
     /// Transfers `reward_amount` from `verifier` to each assignee proportionally
@@ -367,6 +464,19 @@ impl MergeMintContract {
             if assignee == verifier {
                 fail(ContractError::VerifierCannotBeAssignee);
             }
+        }
+
+        if !bounty.milestones.is_empty() {
+            if !bounty.milestones.iter().all(|m| m.completed) {
+                fail(ContractError::NotAllMilestonesCompleted);
+            }
+            let previous_status = bounty.status.clone();
+            bounty.status = Symbol::new(&env, STATUS_COMPLETED);
+            storage::store_bounty(&env, &bounty_id, &bounty);
+            storage::move_bounty_status(&env, &bounty_id, &previous_status, &bounty.status);
+            let (primary_assignee, _) = bounty.assignees.get(0).unwrap();
+            events::emit_bounty_completed(&env, &bounty_id, &primary_assignee);
+            return;
         }
 
         // Checks-effects-interactions pattern:
@@ -438,6 +548,19 @@ impl MergeMintContract {
         let threshold = if bounty.approval_threshold == 0 { 1 } else { bounty.approval_threshold };
 
         if approval_count >= threshold {
+            if !bounty.milestones.is_empty() {
+                if !bounty.milestones.iter().all(|m| m.completed) {
+                    fail(ContractError::NotAllMilestonesCompleted);
+                }
+                let previous_status = bounty.status.clone();
+                bounty.status = Symbol::new(&env, STATUS_COMPLETED);
+                storage::store_bounty(&env, &bounty_id, &bounty);
+                storage::move_bounty_status(&env, &bounty_id, &previous_status, &bounty.status);
+                let (primary_assignee, _) = bounty.assignees.get(0).unwrap();
+                events::emit_bounty_completed(&env, &bounty_id, &primary_assignee);
+                return;
+            }
+
             let token = TokenClient::new(&env, &bounty.reward_token);
             distribute_payout(
                 &env, &bounty_id, &bounty.assignees, &verifier, &token, bounty.reward_amount,
@@ -526,29 +649,39 @@ impl MergeMintContract {
                 fail(ContractError::BountyHasNoAssignee);
             }
 
-            let token = TokenClient::new(&env, &bounty.reward_token);
+            if !bounty.milestones.is_empty() {
+                if !bounty.milestones.iter().all(|m| m.completed) {
+                    fail(ContractError::NotAllMilestonesCompleted);
+                }
+                let previous_status = bounty.status.clone();
+                bounty.status = Symbol::new(&env, STATUS_COMPLETED);
+                storage::store_bounty(&env, &bounty_id, &bounty);
+                storage::move_bounty_status(&env, &bounty_id, &previous_status, &bounty.status);
+            } else {
+                let token = TokenClient::new(&env, &bounty.reward_token);
 
-            for (assignee, share_bp) in bounty.assignees.iter() {
-                let payout =
-                    (bounty.reward_amount as i128) * (share_bp as i128) / 10_000_i128;
-                token.transfer(&arbitrator, &assignee, &payout);
+                for (assignee, share_bp) in bounty.assignees.iter() {
+                    let payout =
+                        (bounty.reward_amount as i128) * (share_bp as i128) / 10_000_i128;
+                    token.transfer(&arbitrator, &assignee, &payout);
 
-                let mut contrib = storage::get_contributor(&env, &assignee)
-                    .unwrap_or_else(|| Contributor::new(assignee.clone()));
+                    let mut contrib = storage::get_contributor(&env, &assignee)
+                        .unwrap_or_else(|| Contributor::new(assignee.clone()));
 
-                contrib.reputation += 10;
-                contrib.total_earned += payout;
-                contrib.contribution_count += 1;
-                decrement_active_claims(&mut contrib);
+                    contrib.reputation += 10;
+                    contrib.total_earned += payout;
+                    contrib.contribution_count += 1;
+                    decrement_active_claims(&mut contrib);
 
-                storage::store_contributor(&env, &assignee, &contrib);
-                events::emit_reward_paid(&env, &bounty_id, &assignee, &payout);
+                    storage::store_contributor(&env, &assignee, &contrib);
+                    events::emit_reward_paid(&env, &bounty_id, &assignee, &payout);
+                }
+
+                let previous_status = bounty.status.clone();
+                bounty.status = Symbol::new(&env, STATUS_COMPLETED);
+                storage::store_bounty(&env, &bounty_id, &bounty);
+                storage::move_bounty_status(&env, &bounty_id, &previous_status, &bounty.status);
             }
-
-            let previous_status = bounty.status.clone();
-            bounty.status = Symbol::new(&env, STATUS_COMPLETED);
-            storage::store_bounty(&env, &bounty_id, &bounty);
-            storage::move_bounty_status(&env, &bounty_id, &previous_status, &bounty.status);
         } else if resolution == resolve_cancel {
             // Refund escrowed reward to creator before mutating status.
             let token = TokenClient::new(&env, &bounty.reward_token);

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,6 +27,11 @@ pub enum ContractError {
     BountyNotDisputed,
     NotArbitrator,
     ApprovalThresholdExceedsVerifiers,
+    InvalidRewardToken,
+    MilestoneAlreadyCompleted,
+    NotAllMilestonesCompleted,
+    InvalidMilestoneIndex,
+    MilestoneRewardsMismatch,
 }
 
 /// Convert a `ContractError` to its canonical panic message and panic.
@@ -64,6 +69,15 @@ pub const fn message(e: ContractError) -> &'static str {
         ContractError::NotArbitrator => "caller is not authorized to resolve this dispute",
         ContractError::ApprovalThresholdExceedsVerifiers => {
             "approval_threshold cannot exceed the number of required_verifiers"
+        }
+        ContractError::InvalidRewardToken => "invalid reward_token address",
+        ContractError::MilestoneAlreadyCompleted => "milestone is already completed",
+        ContractError::NotAllMilestonesCompleted => {
+            "not all milestones are completed"
+        }
+        ContractError::InvalidMilestoneIndex => "invalid milestone index",
+        ContractError::MilestoneRewardsMismatch => {
+            "milestone rewards do not sum to reward_amount"
         }
     }
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -70,3 +70,16 @@ pub fn emit_dispute_resolved(
         (bounty_id.clone(), resolution.clone()),
     );
 }
+
+pub fn emit_milestone_completed(
+    env: &Env,
+    bounty_id: &BountyId,
+    milestone_index: u32,
+    amount: &i128,
+) {
+    let topic = Symbol::new(env, "milestone_completed");
+    env.events().publish(
+        (topic, milestone_index),
+        (bounty_id.clone(), *amount),
+    );
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -31,18 +31,21 @@ fn make_bounty(
     tag: &str,
     deadline: Option<u32>,
 ) -> crate::types::BountyId {
+    let sac = env.register_stellar_asset_contract_v2(creator.clone());
+    let token_addr = sac.address();
     client.create_bounty(
         creator,
         &Symbol::new(env, tag),
         &String::from_str(env, "desc"),
         &1000,
-        &Address::generate(env),
+        &token_addr,
         &0,
         &deadline,
         &Vec::new(env),
         &1,
         &None,
         &1,
+        &Vec::new(env),
     )
 }
 
@@ -81,6 +84,7 @@ fn make_bounty_with_token(
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
     (bounty_id, token_addr)
 }
@@ -105,13 +109,14 @@ fn test_tags_stored_and_retrieved() {
         &Symbol::new(&env, "tagged"),
         &String::from_str(&env, "desc"),
         &1000,
-        &Address::generate(&env),
+        &create_token_and_mint(&env, &creator, &contract_id, 0),
         &0,
         &None,
         &tags,
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
 
     let bounty = client.get_bounty(&bounty_id).unwrap();
@@ -132,13 +137,14 @@ fn test_empty_tags_valid() {
         &Symbol::new(&env, "no_tags"),
         &String::from_str(&env, "desc"),
         &1000,
-        &Address::generate(&env),
+        &create_token_and_mint(&env, &creator, &contract_id, 0),
         &0,
         &None,
         &Vec::new(&env),
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
 
     let bounty = client.get_bounty(&bounty_id).unwrap();
@@ -164,13 +170,14 @@ fn test_five_tags_allowed() {
         &Symbol::new(&env, "max_tags"),
         &String::from_str(&env, "desc"),
         &1000,
-        &Address::generate(&env),
+        &create_token_and_mint(&env, &creator, &contract_id, 0),
         &0,
         &None,
         &tags,
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
 
     let bounty = client.get_bounty(&bounty_id).unwrap();
@@ -195,13 +202,14 @@ fn test_too_many_tags_panics() {
         &Symbol::new(&env, "overtags"),
         &String::from_str(&env, "desc"),
         &1000,
-        &Address::generate(&env),
+        &create_token_and_mint(&env, &creator, &contract_id, 0),
         &0,
         &None,
         &tags,
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
 }
 
@@ -416,13 +424,14 @@ fn test_create_bounty_rejects_past_deadline() {
         &Symbol::new(&env, "past_dl"),
         &String::from_str(&env, "desc"),
         &1000,
-        &Address::generate(&env),
+        &create_token_and_mint(&env, &creator, &contract_id, 0),
         &0,
         &Some(50),
         &Vec::new(&env),
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
 }
 
@@ -439,13 +448,14 @@ fn test_create_bounty_accepts_future_deadline() {
         &Symbol::new(&env, "future_dl"),
         &String::from_str(&env, "desc"),
         &1000,
-        &Address::generate(&env),
+        &create_token_and_mint(&env, &creator, &contract_id, 0),
         &0,
         &Some(100),
         &Vec::new(&env),
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
 }
 
@@ -460,7 +470,7 @@ fn test_create_bounty() {
     let client = MergeMintContractClient::new(&env, &contract_id);
 
     let reward_amount: i128 = 1000;
-    let reward_token = Address::generate(&env);
+    let reward_token = create_token_and_mint(&env, &creator, &contract_id, 0);
     let bounty_id = client.create_bounty(
         &creator,
         &Symbol::new(&env, "test_b"),
@@ -473,6 +483,7 @@ fn test_create_bounty() {
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
 
     let bounty = client.get_bounty(&bounty_id).unwrap();
@@ -502,13 +513,14 @@ fn test_create_bounty_rejects_zero_reward() {
         &Symbol::new(&env, "zero_rew"),
         &String::from_str(&env, "desc"),
         &0,
-        &Address::generate(&env),
+        &create_token_and_mint(&env, &creator, &contract_id, 0),
         &0,
         &None,
         &Vec::new(&env),
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
 }
 
@@ -525,13 +537,14 @@ fn test_create_bounty_rejects_negative_reward() {
         &Symbol::new(&env, "neg_rew"),
         &String::from_str(&env, "desc"),
         &(-50),
-        &Address::generate(&env),
+        &create_token_and_mint(&env, &creator, &contract_id, 0),
         &0,
         &None,
         &Vec::new(&env),
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
 }
 
@@ -548,13 +561,14 @@ fn test_create_bounty_rejects_below_minimum_reward() {
         &Symbol::new(&env, "small_rew"),
         &String::from_str(&env, "desc"),
         &50,
-        &Address::generate(&env),
+        &create_token_and_mint(&env, &creator, &contract_id, 0),
         &0,
         &None,
         &Vec::new(&env),
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
 }
 
@@ -569,13 +583,14 @@ fn test_claim_bounty() {
         &Symbol::new(&env, "bounty_1"),
         &String::from_str(&env, "desc"),
         &1000,
-        &Address::generate(&env),
+        &create_token_and_mint(&env, &creator, &contract_id, 0),
         &0,
         &None,
         &Vec::new(&env),
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
     client.claim_bounty(&contributor, &bounty_id);
 
@@ -597,13 +612,14 @@ fn test_creator_cannot_claim_own_bounty() {
         &Symbol::new(&env, "bounty_1"),
         &String::from_str(&env, "desc"),
         &1000,
-        &Address::generate(&env),
+        &create_token_and_mint(&env, &creator, &contract_id, 0),
         &0,
         &None,
         &Vec::new(&env),
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
     client.claim_bounty(&creator, &bounty_id);
 }
@@ -615,7 +631,7 @@ fn test_bounty_count() {
     let client = MergeMintContractClient::new(&env, &contract_id);
 
     assert_eq!(client.get_bounty_count(), 0);
-    let reward_token = Address::generate(&env);
+    let reward_token = create_token_and_mint(&env, &creator, &contract_id, 0);
     client.create_bounty(
         &creator,
         &Symbol::new(&env, "bounty_a"),
@@ -628,6 +644,7 @@ fn test_bounty_count() {
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
     assert_eq!(client.get_bounty_count(), 1);
     client.create_bounty(
@@ -642,6 +659,7 @@ fn test_bounty_count() {
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
     assert_eq!(client.get_bounty_count(), 2);
 }
@@ -798,13 +816,14 @@ fn test_claim_bounty_rejects_low_reputation() {
         &Symbol::new(&env, "rep_b"),
         &String::from_str(&env, "desc"),
         &1000,
-        &Address::generate(&env),
+        &create_token_and_mint(&env, &creator, &contract_id, 0),
         &10,
         &None,
         &Vec::new(&env),
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
 
     let bounty_id = client.get_bounties_by_creator(&creator).get(0).unwrap();
@@ -1072,13 +1091,14 @@ fn test_double_complete_panics() {
         &Symbol::new(&env, "dbl_complete"),
         &String::from_str(&env, "desc"),
         &1000,
-        &Address::generate(&env),
+        &create_token_and_mint(&env, &creator, &contract_id, 0),
         &0,
         &None,
         &Vec::new(&env),
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
 
     // Bounty is "open", not "in_progress" — must panic.
@@ -1198,13 +1218,14 @@ fn test_assignee_cannot_self_verify() {
         &Symbol::new(&env, "self_verify"),
         &String::from_str(&env, "desc"),
         &1000,
-        &Address::generate(&env),
+        &create_token_and_mint(&env, &creator, &contract_id, 0),
         &0,
         &None,
         &Vec::new(&env),
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
 
     client.claim_bounty(&contributor, &bounty_id);
@@ -1367,6 +1388,7 @@ fn test_resolve_dispute_complete_pays_from_arbitrator() {
         &1,
         &None,
         &1,
+        &Vec::new(env),
     );
 
     client.claim_bounty(&contributor, &bounty_id);
@@ -1435,6 +1457,7 @@ fn make_multi_bounty_with_token(
         &max_assignees,
         &None,
         &1,
+        &Vec::new(env),
     );
     (bounty_id, token_addr)
 }
@@ -1721,4 +1744,291 @@ fn test_two_assignees_uneven_reward_integer_division_loss() {
         integer_division_loss, 1,
         "integer-division loss is 1 token for reward_amount=9_999 with 2 assignees"
     );
+}
+
+// ===========================================================================
+// Issue 429 — minimum reward_amount
+// ===========================================================================
+
+/// Creating a bounty with reward_amount below MIN_REWARD_AMOUNT must panic.
+#[test]
+#[should_panic(expected = "reward_amount is below the minimum allowed")]
+fn test_create_bounty_below_minimum_reward_panics() {
+    let (env, creator, _contributor, _verifier) = setup_test();
+    let contract_id = env.register(MergeMintContract, ());
+    let client = MergeMintContractClient::new(&env, &contract_id);
+
+    client.create_bounty(
+        &creator,
+        &Symbol::new(&env, "small_rew"),
+        &String::from_str(&env, "desc"),
+        &50,
+        &create_token_and_mint(&env, &creator, &contract_id, 0),
+        &0,
+        &None,
+        &Vec::new(&env),
+        &1,
+        &None,
+        &1,
+        &Vec::new(&env),
+    );
+}
+
+// ===========================================================================
+// Issue 430 — validate reward_token
+// ===========================================================================
+
+/// Creating a bounty with a non-token address must panic.
+#[test]
+#[should_panic(expected = "invalid reward_token address")]
+fn test_create_bounty_rejects_non_token_address() {
+    let (env, creator, _contributor, _verifier) = setup_test();
+    let contract_id = env.register(MergeMintContract, ());
+    let client = MergeMintContractClient::new(&env, &contract_id);
+
+    client.create_bounty(
+        &creator,
+        &Symbol::new(&env, "bad_token"),
+        &String::from_str(&env, "desc"),
+        &1000,
+        &Address::generate(&env),
+        &0,
+        &None,
+        &Vec::new(&env),
+        &1,
+        &None,
+        &1,
+        &Vec::new(env),
+    );
+}
+
+// ===========================================================================
+// Issue 427 — milestone-based completion
+// ===========================================================================
+
+/// Milestones are stored on the bounty and retrieved via get_bounty.
+#[test]
+fn test_create_bounty_with_milestones_stores_milestones() {
+    let (env, creator, _contributor, _verifier) = setup_test();
+    let contract_id = env.register(MergeMintContract, ());
+    let client = MergeMintContractClient::new(&env, &contract_id);
+
+    let mut milestones: Vec<crate::contract::Milestone> = Vec::new(&env);
+    let m1 = crate::contract::Milestone {
+        description: Symbol::new(&env, "build"),
+        reward: 500,
+        completed: false,
+    };
+    let m2 = crate::contract::Milestone {
+        description: Symbol::new(&env, "deploy"),
+        reward: 500,
+        completed: false,
+    };
+    milestones.push_back(m1);
+    milestones.push_back(m2);
+
+    let bounty_id = client.create_bounty(
+        &creator,
+        &Symbol::new(&env, "milestone_b"),
+        &String::from_str(&env, "desc"),
+        &1000,
+        &create_token_and_mint(&env, &creator, &contract_id, 0),
+        &0,
+        &None,
+        &Vec::new(&env),
+        &1,
+        &None,
+        &1,
+        &milestones,
+    );
+
+    let bounty = client.get_bounty(&bounty_id).unwrap();
+    assert_eq!(bounty.milestones.len(), 2);
+    assert_eq!(bounty.milestones.get(0).unwrap().description, Symbol::new(&env, "build"));
+    assert_eq!(bounty.milestones.get(0).unwrap().reward, 500);
+    assert!(!bounty.milestones.get(1).unwrap().completed);
+}
+
+/// Completing a milestone pays out its reward and marks it completed.
+#[test]
+fn test_complete_milestone_pays_and_marks_completed() {
+    let (env, creator, contributor, verifier) = setup_test();
+    let contract_id = env.register(MergeMintContract, ());
+    let client = MergeMintContractClient::new(&env, &contract_id);
+
+    let reward_amount: i128 = 1000;
+    let token_addr = create_token_and_mint(&env, &creator, &verifier, reward_amount);
+
+    let mut milestones: Vec<crate::contract::Milestone> = Vec::new(&env);
+    let m1 = crate::contract::Milestone {
+        description: Symbol::new(&env, "build"),
+        reward: 500,
+        completed: false,
+    };
+    let m2 = crate::contract::Milestone {
+        description: Symbol::new(&env, "deploy"),
+        reward: 500,
+        completed: false,
+    };
+    milestones.push_back(m1);
+    milestones.push_back(m2);
+
+    let bounty_id = client.create_bounty(
+        &creator,
+        &Symbol::new(&env, "ms_pay"),
+        &String::from_str(&env, "desc"),
+        &reward_amount,
+        &token_addr,
+        &0,
+        &None,
+        &Vec::new(&env),
+        &1,
+        &None,
+        &1,
+        &milestones,
+    );
+
+    client.claim_bounty(&contributor, &bounty_id);
+    client.complete_milestone(&verifier, &bounty_id, 0);
+
+    let bounty = client.get_bounty(&bounty_id).unwrap();
+    assert!(bounty.milestones.get(0).unwrap().completed);
+    assert!(!bounty.milestones.get(1).unwrap().completed);
+
+    let token_client = StellarAssetClient::new(&env, &token_addr);
+    assert_eq!(token_client.balance(&contributor), 500);
+}
+
+/// Completing the same milestone twice must panic.
+#[test]
+#[should_panic(expected = "milestone is already completed")]
+fn test_double_complete_milestone_panics() {
+    let (env, creator, contributor, verifier) = setup_test();
+    let contract_id = env.register(MergeMintContract, ());
+    let client = MergeMintContractClient::new(&env, &contract_id);
+
+    let reward_amount: i128 = 1000;
+    let token_addr = create_token_and_mint(&env, &creator, &verifier, reward_amount);
+
+    let mut milestones: Vec<crate::contract::Milestone> = Vec::new(&env);
+    milestones.push_back(crate::contract::Milestone {
+        description: Symbol::new(&env, "build"),
+        reward: 500,
+        completed: false,
+    });
+    milestones.push_back(crate::contract::Milestone {
+        description: Symbol::new(&env, "deploy"),
+        reward: 500,
+        completed: false,
+    });
+
+    let bounty_id = client.create_bounty(
+        &creator,
+        &Symbol::new(&env, "ms_double"),
+        &String::from_str(&env, "desc"),
+        &reward_amount,
+        &token_addr,
+        &0,
+        &None,
+        &Vec::new(&env),
+        &1,
+        &None,
+        &1,
+        &milestones,
+    );
+
+    client.claim_bounty(&contributor, &bounty_id);
+    client.complete_milestone(&verifier, &bounty_id, 0);
+    client.complete_milestone(&verifier, &bounty_id, 0);
+}
+
+/// complete_bounty must fail if milestones exist but are not all completed.
+#[test]
+#[should_panic(expected = "not all milestones are completed")]
+fn test_complete_bounty_requires_all_milestones_completed() {
+    let (env, creator, contributor, verifier) = setup_test();
+    let contract_id = env.register(MergeMintContract, ());
+    let client = MergeMintContractClient::new(&env, &contract_id);
+
+    let reward_amount: i128 = 1000;
+    let token_addr = create_token_and_mint(&env, &creator, &verifier, reward_amount);
+
+    let mut milestones: Vec<crate::contract::Milestone> = Vec::new(&env);
+    milestones.push_back(crate::contract::Milestone {
+        description: Symbol::new(&env, "build"),
+        reward: 500,
+        completed: false,
+    });
+    milestones.push_back(crate::contract::Milestone {
+        description: Symbol::new(&env, "deploy"),
+        reward: 500,
+        completed: false,
+    });
+
+    let bounty_id = client.create_bounty(
+        &creator,
+        &Symbol::new(&env, "ms_incomplete"),
+        &String::from_str(&env, "desc"),
+        &reward_amount,
+        &token_addr,
+        &0,
+        &None,
+        &Vec::new(&env),
+        &1,
+        &None,
+        &1,
+        &milestones,
+    );
+
+    client.claim_bounty(&contributor, &bounty_id);
+    client.complete_milestone(&verifier, &bounty_id, 0);
+    client.complete_bounty(&verifier, &bounty_id);
+}
+
+/// complete_bounty succeeds after all milestones are completed.
+#[test]
+fn test_complete_bounty_succeeds_after_all_milestones() {
+    let (env, creator, contributor, verifier) = setup_test();
+    let contract_id = env.register(MergeMintContract, ());
+    let client = MergeMintContractClient::new(&env, &contract_id);
+
+    let reward_amount: i128 = 1000;
+    let token_addr = create_token_and_mint(&env, &creator, &verifier, reward_amount);
+
+    let mut milestones: Vec<crate::contract::Milestone> = Vec::new(&env);
+    milestones.push_back(crate::contract::Milestone {
+        description: Symbol::new(&env, "build"),
+        reward: 500,
+        completed: false,
+    });
+    milestones.push_back(crate::contract::Milestone {
+        description: Symbol::new(&env, "deploy"),
+        reward: 500,
+        completed: false,
+    });
+
+    let bounty_id = client.create_bounty(
+        &creator,
+        &Symbol::new(&env, "ms_full"),
+        &String::from_str(&env, "desc"),
+        &reward_amount,
+        &token_addr,
+        &0,
+        &None,
+        &Vec::new(&env),
+        &1,
+        &None,
+        &1,
+        &milestones,
+    );
+
+    client.claim_bounty(&contributor, &bounty_id);
+    client.complete_milestone(&verifier, &bounty_id, 0);
+    client.complete_milestone(&verifier, &bounty_id, 1);
+    client.complete_bounty(&verifier, &bounty_id);
+
+    let bounty = client.get_bounty(&bounty_id).unwrap();
+    assert_eq!(bounty.status, Symbol::new(&env, "completed"));
+    assert!(bounty.milestones.get(0).unwrap().completed);
+    assert!(bounty.milestones.get(1).unwrap().completed);
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,7 +38,6 @@ pub enum DataKey {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[contracttype]
-// TODO(#427): unused until milestone-based partial bounty completion lands
 pub struct Milestone {
     pub description: Symbol,
     pub reward: i128,
@@ -67,6 +66,8 @@ pub struct Bounty {
     /// At most 5 tags are allowed; `create_bounty` panics with `TooManyTags`
     /// if the caller supplies more than 5.
     pub tags: Vec<Symbol>,
+    /// Optional staged payouts. When empty, the bounty is all-or-nothing.
+    pub milestones: Vec<Milestone>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION

- Add max_assignees, required_verifiers, approval_threshold, milestones to create_bounty signature
- Enforce MIN_REWARD_AMOUNT in create_bounty (closes #429)
- Add complete_milestone entry point with payout and completion guard
- Adjust complete_bounty and approve_completion to require all milestones completed
- Add on-chain reward_token validation via balance simulation (closes #430)
- Update design note in docs/create-bounty-params-design.md (closes #424)
- Update SDK types and transaction builder for new params
- Update frontend types and BountyDetail milestone rendering (closes #427)

closes #424, #429, #427, #430
