### PR TITLE
Fix: 37. Test `create_bounty` rejects non-positive `reward_amount`

### DIFF
--- a/tests/create_bounty_validation.rs
+++ b/tests/create_bounty_validation.rs
@@ -1,0 +1,38 @@
+use bounty_program::*;
+
+#[test]
+#[should_panic(expected = "RewardMustBePositive")]
+fn test_create_bounty_zero_reward_panics() {
+    let mut bounties = vec![];
+    create_bounty(
+        &mut bounties,
+        "Test Bounty".to_string(),
+        "Description".to_string(),
+        0,
+    );
+}
+
+#[test]
+#[should_panic(expected = "RewardMustBePositive")]
+fn test_create_bounty_negative_reward_panics() {
+    let mut bounties = vec![];
+    create_bounty(
+        &mut bounties,
+        "Test Bounty".to_string(),
+        "Description".to_string(),
+        -100,
+    );
+}
+
+#[test]
+fn test_create_bounty_positive_reward_succeeds() {
+    let mut bounties = vec![];
+    create_bounty(
+        &mut bounties,
+        "Valid Bounty".to_string(),
+        "Valid Description".to_string(),
+        100,
+    );
+    assert_eq!(bounties.len(), 1);
+    assert_eq!(bounties[0].reward_amount, 100);
+}


### PR DESCRIPTION
Resolves #449

## Solution

test: cover RewardMustBePositive guard in create_bounty

## Quality Checks

All pre-submission quality gates passed:
- **meaningful**: ✅ Passed
- **syntax**: ✅ Passed
- **duplicate**: ✅ Passed
- **title**: ✅ Passed
- **tests**: ✅ Passed



---

🤖 Generated by Talos | Bounty reward: $0