### PR TITLE
Add troubleshooting/testing docs, reconcile shared-types and pause-upgrade docs

### DIFF
--- a/docs/contributor-faq.md
+++ b/docs/contributor-faq.md
@@ -43,3 +43,48 @@ Each time a verifier calls `complete_bounty` for a bounty you completed, your re
 **How do I dispute a completion decision?**
 
 There is currently no on-chain dispute mechanism. If you believe a completion was handled incorrectly — for example, a reward was not paid after work was accepted — raise the issue with the project maintainers. On-chain dispute resolution is a planned future feature.
+
+---
+
+## Troubleshooting
+
+**`cargo build --target wasm32-unknown-unknown` fails, or produces no `.wasm` file where a doc/script expects it**
+
+`rust-toolchain.toml` pins the `wasm32v1-none` target, and that's also the target CI actually builds and inspects (`.github/workflows/build.yml`, `.github/workflows/interface-check.yml`). Some setup docs and scripts still reference the older `wasm32-unknown-unknown` target. If a build command from a doc or script doesn't produce a binary where you expect it, try the toolchain-pinned target instead:
+
+```bash
+rustup target add wasm32v1-none
+cargo build --release --target wasm32v1-none
+```
+
+The resulting `.wasm` will be under `target/wasm32v1-none/release/`, not `target/wasm32-unknown-unknown/release/`.
+
+---
+
+**`stellar` command not found, or behaves differently than expected**
+
+Install (or reinstall) a pinned version of the CLI:
+
+```bash
+cargo install stellar-cli --locked
+```
+
+If you already have `stellar-cli` installed from a while back, an outdated version is a common source of flags or subcommands not matching what a script expects. Reinstalling with `--locked` gets you a consistent, reproducible build.
+
+---
+
+**`stellar account fund` / Friendbot fails, or a testnet transaction fails with an unfunded-account error**
+
+Friendbot (the testnet funding faucet) is occasionally rate-limited or briefly unavailable. Wait a minute and retry the fund command. If it keeps failing, confirm you're targeting `--network testnet` and not `futurenet` or `local` by mistake.
+
+---
+
+**`scripts/integration_test.sh` hangs or fails to reach the sandbox**
+
+This script needs a local Soroban sandbox running via Docker. Make sure Docker is installed and running before invoking the script — see `docs/testing.md` for the full prerequisites and what each test script actually covers.
+
+---
+
+**A contract invocation fails with an "unrecognized argument" or similar CLI error**
+
+Double-check the flag names against the contract's actual current entrypoint signature (in `src/contract/mutations.rs`), not just an example in a doc or script — entrypoint parameters have changed over time, and not every doc/script has been kept in sync. `docs/testing.md` calls out at least one known case of this drift.

--- a/docs/pause-upgrade-strategy.md
+++ b/docs/pause-upgrade-strategy.md
@@ -3,6 +3,14 @@
 **Status:** Proposal — follow-up implementation ticket required before merging any code.
 **Date:** 2026-07-29
 
+**Implementation status (confirmed against current source):** Nothing in this
+document has been implemented yet. There is no `DataKey::Admin`, `DataKey::Paused`,
+`init`/`pause`/`unpause`/`upgrade` function, or `assert_not_paused` guard anywhere
+in `src/`. Every mutating entrypoint in `src/contract/mutations.rs` runs
+unconditionally once `require_auth` passes. This remains a design proposal only —
+none of Phase 1 (Option A) or Phase 2 (Option B) below has landed, and none of the
+three follow-up tickets listed at the bottom of this doc has been opened yet.
+
 ---
 
 ## Problem

--- a/docs/shared-type-generation.md
+++ b/docs/shared-type-generation.md
@@ -52,3 +52,30 @@ This is a design note only. Given the cross-repo scope (contracts, backend,
 frontend, and SDK all need coordinated changes), implementation should be
 tracked as a separate follow-up ticket with its own plan and tests
 (round-trip type checks wired into CI).
+
+## Decision record
+
+**What actually landed:** [#523](https://github.com/mergemint-mint/mergemint-contracts/issues/523)
+(PR [#544](https://github.com/mergemint-mint/mergemint-contracts/pull/544)) took
+a much narrower approach than either option above: it consolidated the `Bounty`/
+`Contributor` interfaces that were previously duplicated *within the SDK package*
+into a single `sdk/src/types.ts`. It did not implement contract-to-TypeScript
+codegen (Option 1) or a shared schema (Option 2), and it did not touch the
+backend or frontend.
+
+[#111](https://github.com/mergemint-mint/mergemint-contracts/issues/111) (a
+related but distinct ask — a storage-migration strategy for `Bounty` struct
+changes, not type-duplication itself) was closed without an associated
+implementation; that topic remains undocumented.
+
+**Remaining follow-up (not yet done):**
+- `mergemint-backend/src/scval.rs` and `mergemint-backend/src/dto.rs` still
+  hand-write their own shapes, independently of both the contract's
+  `src/types.rs` and `sdk/src/types.ts`.
+- `frontend/src/types.ts` and `frontend/src/lib/types.ts` still hand-write two
+  *different* shapes of `Bounty`/`Contributor` (e.g. `reward: string` vs.
+  `rewardAmount: bigint`), neither of which imports from `sdk/src/types.ts`.
+- The original problem this doc set out to solve — a contract field rename
+  silently going out of sync with the backend/frontend/SDK — is therefore
+  still open outside the SDK package itself. The codegen-from-Rust approach
+  recommended above has not been attempted.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,77 @@
+# Testing
+
+This project has two shell scripts under `scripts/` in addition to `cargo test`:
+`scripts/integration_test.sh` and `scripts/smoke_test.sh`. Both drive the compiled
+contract through its actual CLI surface (`stellar contract invoke`) rather than
+calling Rust functions directly, so they exercise the same path a real integrator
+would use.
+
+## `scripts/integration_test.sh`
+
+**What it covers:** a full local end-to-end pass — starts a local Soroban sandbox,
+builds the WASM, deploys a mock reward token and the MergeMint contract, then walks
+through `create_bounty` → `claim_bounty` → `complete_bounty` → `update_contributor_metadata`,
+asserting bounty count, assignee membership, contributor reputation/contribution
+count, and final bounty status at each step.
+
+**When to run it:** locally, before opening a PR that touches contract logic. It's
+the fastest way to catch a regression in the bounty lifecycle without needing a
+funded testnet account.
+
+**Prerequisites:**
+- `stellar-cli` installed (`cargo install stellar-cli --locked`)
+- Docker installed and running (the script starts a local sandbox container)
+- The `wasm32v1-none` Rust target installed (`rustup target add wasm32v1-none`) —
+  see the note below on target mismatches
+
+**Usage:**
+```bash
+./scripts/integration_test.sh
+```
+No environment variables are required; it manages its own local identities and
+network.
+
+## `scripts/smoke_test.sh`
+
+**What it covers:** a minimal build → deploy → create → claim → complete pass
+against a real network (testnet by default), intended as a quick post-deploy sanity
+check rather than a full regression suite.
+
+**When to run it:** after deploying to testnet (or another live network), to
+confirm the deployed contract responds to the basic bounty lifecycle.
+
+**Prerequisites:**
+- `stellar-cli` installed
+- A funded account on the target network (see the Getting Started guide for
+  funding a testnet account via Friendbot)
+
+**Required environment variables:**
+| Variable  | Required | Default    | Description                                  |
+|-----------|----------|------------|-----------------------------------------------|
+| `ACCOUNT` | Yes      | —          | Funded account public key used as source, creator, and claimant |
+| `NETWORK` | No       | `testnet`  | Network alias passed to `stellar` commands    |
+
+**Usage:**
+```bash
+ACCOUNT=GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX ./scripts/smoke_test.sh
+```
+
+> **Known drift:** `smoke_test.sh`'s `create_bounty` call currently uses `--reward`
+> and `--deadline` flags, and its `claim_bounty`/`complete_bounty` calls use
+> `--claimant`/`--creator`. The contract's actual current entrypoints
+> (`src/contract/mutations.rs`) expect `--reward_amount`/`--reward_token`/
+> `--min_reputation` for `create_bounty`, and `--contributor`/`--bounty_id` and
+> `--verifier`/`--bounty_id` for `claim_bounty`/`complete_bounty` respectively —
+> matching `integration_test.sh`, which is up to date. Until `smoke_test.sh` is
+> fixed to match, expect it to fail with an unrecognized-argument error; use
+> `integration_test.sh` as the reference for the current CLI shape in the
+> meantime.
+
+## Build target note
+
+Both scripts (and `docs/getting-started.md`) currently look for the WASM binary
+under `target/wasm32-unknown-unknown/release/`. CI (`.github/workflows/build.yml`,
+`.github/workflows/interface-check.yml`) and `rust-toolchain.toml` both build with
+`wasm32v1-none` instead, which places the binary under
+`target/wasm32v1-none/release/`. If a script reports a missing WASM file, check
+which target actually produced your build.


### PR DESCRIPTION
#736: Adds a Troubleshooting section to docs/contributor-faq.md covering the build-target mismatch between rust-toolchain.toml/CI (wasm32v1-none) and the docs/scripts that still reference wasm32-unknown-unknown, stellar-cli install/version issues, Friendbot funding failures, the Docker prerequisite for integration_test.sh, and stale CLI flags vs. the contract's actual current entrypoint signatures.

#735: Adds a Decision record to docs/shared-type-generation.md documenting what #523/PR #544 actually implemented (consolidating the SDK's own internal duplication into sdk/src/types.ts) versus the broader codegen-from- contract approach this doc originally recommended, and lists what's still duplicated (backend DTOs, and two different hand-written frontend shapes) as open follow-up. Also notes #111 was closed without an associated implementation.

#733: Adds docs/testing.md covering scripts/integration_test.sh (full local sandbox lifecycle test, Docker-dependent) and scripts/smoke_test.sh (post-deploy testnet sanity check, requires ACCOUNT/NETWORK), including prerequisites and usage for each. Flags that smoke_test.sh's CLI flags (--reward/--deadline/--claimant/--creator) have drifted from the contract's actual current entrypoints and will fail until fixed, and that both scripts still target the older wasm32-unknown-unknown build path rather than the wasm32v1-none path CI and rust-toolchain.toml actually use.

#734: Adds a confirmed implementation-status note to the top of docs/pause-upgrade-strategy.md: verified against src/contract/mutations.rs that no pause/upgrade/admin primitives exist yet, so the entire document remains an unimplemented proposal (including all three follow-up tickets it lists, none of which have been opened).


Closes #736 
Closes #735 
Closes #733 
Closes #734 

## Summary of Changes

<!-- Describe what this PR changes and why. -->

## Related Issue

Closes #

## How to Test

<!-- Steps to verify this change works correctly. -->

1. 
2. 

## Screenshots / Output

<!-- Paste relevant command output, test results, or screenshots. -->

## Checklist

- [ ] Tests added or updated
- [ ] `cargo clippy` passes with no warnings
- [ ] `cargo fmt` applied
- [ ] PR description includes `Closes #<issue_id>`
