### PR TITLE
Fix bounty 257

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,6 +191,72 @@ The two paths into `cancelled` emit different events to let off-chain indexers d
 
 ---
 
+## Solidity / Soroban Lifecycle Parity
+
+This section reconciles the two contracts named in issue #713 — the Solidity
+`BountyRefresh` contract (`contracts/bounty/BountyRefresh.sol`) and the Soroban
+`MergeMintContract` (`src/contract/`) — to confirm whether their bounty-lifecycle
+status transitions match, and to record any intentional divergence.
+
+### Finding: one bounty-lifecycle state machine, two different operational models
+
+Soroban is the **only** place a bounty's lifecycle `status` field is defined and
+transitioned. Its state machine (`open → in_progress → completed | cancelled`, plus
+the `disputed` sub-state) is the canonical bounty lifecycle and is documented in the
+previous section.
+
+The Solidity `BountyRefresh` contract does **not** model a bounty lifecycle at all.
+Its state is a batch/refresh *orchestration* model, scoped to re-computing contributor
+metrics in bulk. It never reads or writes a bounty `status`; it has no `open`,
+`in_progress`, `completed`, `cancelled`, or `disputed` bounty state and no transition
+functions resembling `claim_bounty` / `complete_bounty` / `cancel_bounty` /
+`expire_bounty`. `IBountyManager.sol` likewise exposes only
+`updateContributorMetrics`, `getBountyContributors`, and `getContributorCount`.
+
+This separation is **intentional**: `BountyRefresh` is an off-path operational tool
+for refreshing contributor metrics, not a second implementation of the bounty
+lifecycle. There is therefore no lifecycle to "keep in parity" beyond the Soroban
+machine.
+
+### State-model comparison
+
+| Concern | Solidity `BountyRefresh.sol` | Soroban `MergeMintContract` |
+|---------|------------------------------|-----------------------------|
+| What is modelled | Refresh task / batch run progress | Bounty lifecycle `status` |
+| States | `BountyRefreshTask.completed`, `BountyRefreshTask.failed`; `RefreshBatch.isProcessing`, `RefreshBatch.isCompleted`; `Pausable` | `open`, `in_progress`, `completed`, `cancelled`, `disputed` |
+| Transitions on | `createBatch` → `processBatchParallel` → `finalizeBatch` | `create_bounty` → `claim_bounty` → `complete_bounty` / `cancel_bounty` / `expire_bounty` / `raise_dispute` |
+| Touches bounty `status`? | No | Yes |
+| Auth model | `onlyOwner` + `nonReentrant` + `whenNotPaused` | `require_auth()` per role (creator / contributor / verifier) |
+
+### Lexical overlap with divergent meaning (documented so reviewers don't conflate them)
+
+The token `completed` appears in both contracts but means different things:
+
+- In Soroban, `completed` is a **terminal bounty state**: the reward was paid and
+  reputation updated; no transitions out.
+- In `BountyRefresh`, `RefreshBatch.isCompleted` (and `BountyRefreshTask.completed`)
+  means the **refresh run finished** (success or failure counted), independent of any
+  bounty status. It is an operational flag, not a bounty lifecycle state.
+
+Because the two `completed` values live in unrelated structs and are never bridged,
+there is no shared transition to keep consistent.
+
+### `disputed` state
+
+`disputed` is implemented in Soroban via `raise_dispute` / `resolve_dispute`
+(`src/contract/mutations.rs`). It has no counterpart and no relevance in
+`BountyRefresh`, which has no bounty-lifecycle states to dispute. This is expected
+given the contracts model different concerns.
+
+### Recommended follow-up (out of scope for this PR)
+
+If a future change introduces bounty-lifecycle logic into the Solidity side (e.g. a
+real `BountyManager` that mutates bounty `status`), that is the point at which the two
+state machines must be reconciled for parity. Until then, parity is satisfied by the
+single-sourced Soroban machine.
+
+---
+
 ## Security Model
 
 - All state-changing functions require caller authentication via `require_auth()`


### PR DESCRIPTION
# docs: document bounty lifecycle parity between solidity and soroban contracts

Closes #713

## Summary

Issue #713 asked to compare the bounty lifecycle state machines in
`contracts/bounty/BountyRefresh.sol` (Solidity) and the Soroban `MergeMintContract`
(`src/contract/`), confirm the status transitions match, and record any intentional
divergence in `docs/architecture.md`.

## Finding

The repository contains exactly **one** bounty-lifecycle state machine — the Soroban
contract (`open → in_progress → completed | cancelled`, plus the `disputed` sub-state).
`BountyRefresh.sol` does **not** model a bounty lifecycle at all: its state is a
batch/task refresh orchestration model (`BountyRefreshTask.completed`/`failed`,
`RefreshBatch.isProcessing`/`isCompleted`, `Pausable`), and it never reads or writes a
bounty `status` field. `IBountyManager.sol` only exposes `updateContributorMetrics`,
`getBountyContributors`, and `getContributorCount`.

So the divergence the issue expected is documented as: the bounty lifecycle is
single-sourced in Soroban; `BountyRefresh` is an intentional, separate operational tool.
The only lexical overlap (`completed`) has divergent meaning (terminal bounty state vs.
finished refresh run) and is never bridged, so there is no shared transition to reconcile.
The `disputed` state exists in Soroban and is irrelevant to `BountyRefresh`.

## Change

Single focused addition to `docs/architecture.md`: a new top-level section
`## Solidity / Soroban Lifecycle Parity` (state-model comparison table, lexical-overlap
note, `disputed` note, and a recommended follow-up if real lifecycle logic is ever added
to the Solidity side). Placed immediately before `## Security Model` to follow the
document's existing structure and conventions. No code or test changes.

## Verification

- Documentation-only change; no Solidity/Rust code touched, so the existing Solidity suite
  (`npx hardhat test`) is unaffected. Per the issue, no test changes are required.
- NOTE: the Hardhat toolchain is not installed in this checkout (`hardhat.config` absent;
  `ethers`/`hardhat` not present in `node_modules`), so `npx hardhat test` could not be
  executed here. CI enforces it on the PR. The `docs/architecture.md` edit does not alter
  any compiled artifact.
- `solution.patch` applies cleanly via `git apply --check` against `main`.

## Files

- `docs/architecture.md` (+66 lines)