### PR TITLE
test: cover get_status_count with unrecognized symbol (fixes #748)

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -1223,6 +1223,26 @@ fn test_status_count_matches_index_length() {
     );
 }
 
+/// get_status_count returns 0 (not an error) for a Symbol that is not a
+/// contract-registered status. Storage uses per-status keys; missing keys
+/// default to 0 via `unwrap_or(0)` in `storage::get_status_count`.
+#[test]
+fn test_status_count_unknown_symbol_returns_zero() {
+    let (env, _creator, _contributor, _verifier) = setup_test();
+    let contract_id = env.register(MergeMintContract, ());
+    let client = MergeMintContractClient::new(&env, &contract_id);
+
+    assert_eq!(
+        client.get_status_count(&Symbol::new(&env, "nonexistent")),
+        0
+    );
+    assert_eq!(
+        client.get_status_count(&Symbol::new(&env, "bogus_status")),
+        0
+    );
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "active")), 0);
+}
+
 /// The assignee calling complete_bounty as their own verifier must panic.
 #[test]
 #[should_panic(expected = "verifier cannot be the assignee")]


### PR DESCRIPTION
## Summary

Adds explicit regression coverage for `get_status_count` when passed a `Symbol` that is not a contract-registered status (e.g. `"nonexistent"`, `"bogus_status"`, `"active"`).

**Observed behavior:** returns `0` — storage keys are per-status and missing keys default via `unwrap_or(0)` in `storage::get_status_count` (`src/storage.rs:159-165`). No panic, no error.

Closes #748

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — **69/69 passed** (was 68; +1 new test `test_status_count_unknown_symbol_returns_zero`)

## Payout

Algora/GitHub EVM: `0xbf10d7ef874044c5a48074c049b5d23b57087537`
GitHub: @yaegerbomb42