### PR TITLE
test: document get_status_count behavior for unrecognized Symbol (fixes #748)

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -938,6 +938,22 @@ fn test_status_count_initial_zero() {
     assert_eq!(client.get_status_count(&Symbol::new(&env, "cancelled")), 0);
 }
 
+/// get_status_count returns 0 for an arbitrary Symbol that is not a real
+/// bounty status (storage has no StatusCount key for it).
+#[test]
+fn test_status_count_unrecognized_symbol_returns_zero() {
+    let (env, _creator, _contributor, _verifier) = setup_test();
+    let contract_id = env.register(MergeMintContract, ());
+    let client = MergeMintContractClient::new(&env, &contract_id);
+
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "bogus")), 0);
+    assert_eq!(
+        client.get_status_count(&Symbol::new(&env, "not_a_status")),
+        0
+    );
+    assert_eq!(client.get_status_count(&Symbol::new(&env, "archived")), 0);
+}
+
 /// get_status_count returns 1 after creating a single bounty (open status).
 #[test]
 fn test_status_count_one_on_create() {


### PR DESCRIPTION
## Summary
- Adds `test_status_count_unrecognized_symbol_returns_zero` covering `get_status_count` when passed arbitrary Symbols that are not canonical bounty statuses (`bogus`, `not_a_status`, `archived`).
- Documents the existing contract behavior: missing `StatusCount` storage keys return **0** (via `unwrap_or(0)` in `storage::get_status_count`) rather than panicking.

## Root cause / gap
`get_status_count` accepts any `Symbol`, but prior tests only exercised the four real status values. Issue #748 asked for explicit coverage of unrecognized inputs.

## Test plan
- [x] `cargo test test_status_count_unrecognized_symbol_returns_zero` — pass
- [x] `cargo test` — **69/69** pass (was 68)
- [x] `cargo clippy --all-targets` — clean

Fixes #748

Payout address (EVM): `0xbf10d7ef874044c5a48074c049b5d23b57087537`