### PR TITLE
test: cover get_bounties_by_tag with unknown tags (fixes #749)

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -208,6 +208,42 @@ fn test_too_many_tags_panics() {
     );
 }
 
+/// get_bounties_by_tag returns an empty `Vec` (not an error) for tags that were
+/// never attached to any open bounty. The query scans open bounties and filters
+/// by tag membership; unregistered tags simply match nothing.
+#[test]
+fn test_get_bounties_by_tag_unknown_tags_return_empty() {
+    let (env, creator, _contributor, _verifier) = setup_test();
+    let contract_id = env.register(MergeMintContract, ());
+    let client = MergeMintContractClient::new(&env, &contract_id);
+
+    for tag in ["ghost", "never_used", "zzz", "unregistered"] {
+        assert_eq!(client.get_bounties_by_tag(&Symbol::new(&env, tag)).len(), 0);
+    }
+
+    let mut tags: Vec<Symbol> = Vec::new(&env);
+    tags.push_back(Symbol::new(&env, "bug"));
+    tags.push_back(Symbol::new(&env, "docs"));
+    let _bounty_id = client.create_bounty(
+        &creator,
+        &Symbol::new(&env, "tagged"),
+        &String::from_str(&env, "desc"),
+        &1000,
+        &create_token_and_mint(&env, &creator, &contract_id, 0),
+        &0,
+        &None,
+        &tags,
+        &1,
+        &None,
+        &1,
+        &Vec::new(&env),
+    );
+
+    for tag in ["ghost", "frontend", "rust", "missing"] {
+        assert_eq!(client.get_bounties_by_tag(&Symbol::new(&env, tag)).len(), 0);
+    }
+}
+
 // ===========================================================================
 // Issue 2 — get_bounties_by_creator
 // ===========================================================================


### PR DESCRIPTION
## Summary

Adds fuzz-style regression coverage for `get_bounties_by_tag` when querying tags that were never attached to any open bounty.

**Observed behavior:** returns an empty `Vec` — the query scans open bounties and filters by tag membership; unregistered tags simply match nothing. No panic, no error.

Covers:
- Empty contract + 4 arbitrary tag Symbols
- Contract with a tagged open bounty + 4 additional unknown tag Symbols

Closes #749

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — **69/69 passed** (+1 new test `test_get_bounties_by_tag_unknown_tags_return_empty`)

## Payout

Algora/GitHub EVM: `0xbf10d7ef874044c5a48074c049b5d23b57087537`
GitHub: @yaegerbomb42