### PR TITLE
refactor(errors): wire InvalidRewardToken guard and audit variants (Fixes #649)

### DIFF
--- a/src/contract/mutations.rs
+++ b/src/contract/mutations.rs
@@ -14,6 +14,24 @@ fn generate_bounty_id(env: &Env, count: u64) -> BountyId {
     BountyId(BytesN::from_array(env, &buf))
 }
 
+/// Probe `reward_token` by invoking the SEP-41 `balance` method. Non-token
+/// addresses must fail closed with `InvalidRewardToken` instead of trapping.
+fn validate_reward_token(env: &Env, reward_token: &Address) {
+    use soroban_sdk::{IntoVal, InvokeError, Val, Vec as SorobanVec};
+
+    let mut args: SorobanVec<Val> = SorobanVec::new(env);
+    args.push_back(env.current_contract_address().into_val(env));
+
+    match env.try_invoke_contract::<i128, InvokeError>(
+        reward_token,
+        &Symbol::new(env, "balance"),
+        args,
+    ) {
+        Ok(Ok(_)) => {}
+        Ok(Err(_)) | Err(_) => fail(ContractError::InvalidRewardToken),
+    }
+}
+
 /// Shared payout loop used by `complete_bounty`, `approve_completion`,
 /// and `resolve_dispute`'s "complete" branch.
 ///
@@ -181,8 +199,7 @@ impl MergeMintContract {
             }
         }
 
-        let token = TokenClient::new(&env, &reward_token);
-        token.balance(&env.current_contract_address());
+        validate_reward_token(&env, &reward_token);
 
         if !milestones.is_empty() {
             let mut total: i128 = 0;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: MIT
 
-/// All contract error conditions in one place.
+//! Canonical contract error conditions.
+//!
+//! Each variant must be referenced from contract logic (`fail(ContractError::…)`)
+//! and have a unique panic message. `InvalidRewardToken` is enforced during
+//! `create_bounty` via a non-trapping token `balance` probe.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ContractError {
     BountyNotFound,

--- a/src/test.rs
+++ b/src/test.rs
@@ -390,6 +390,110 @@ fn test_contract_error_messages() {
         message(ContractError::NotArbitrator),
         "caller is not authorized to resolve this dispute"
     );
+    assert_eq!(
+        message(ContractError::RewardBelowMinimum),
+        "reward_amount is below the minimum allowed"
+    );
+    assert_eq!(
+        message(ContractError::MaxAssigneesMustBePositive),
+        "max_assignees must be at least 1"
+    );
+    assert_eq!(
+        message(ContractError::ApprovalThresholdExceedsVerifiers),
+        "approval_threshold cannot exceed the number of required_verifiers"
+    );
+    assert_eq!(
+        message(ContractError::InvalidRewardToken),
+        "invalid reward_token address"
+    );
+    assert_eq!(
+        message(ContractError::MilestoneAlreadyCompleted),
+        "milestone is already completed"
+    );
+    assert_eq!(
+        message(ContractError::NotAllMilestonesCompleted),
+        "not all milestones are completed"
+    );
+    assert_eq!(
+        message(ContractError::InvalidMilestoneIndex),
+        "invalid milestone index"
+    );
+    assert_eq!(
+        message(ContractError::MilestoneRewardsMismatch),
+        "milestone rewards do not sum to reward_amount"
+    );
+}
+
+/// Every `ContractError` variant must map to a distinct panic message.
+#[test]
+fn test_contract_error_messages_are_unique() {
+    use crate::errors::{message, ContractError};
+
+    let variants = [
+        ContractError::BountyNotFound,
+        ContractError::BountyAlreadyAssigned,
+        ContractError::BountyNotOpen,
+        ContractError::BountyNotInProgress,
+        ContractError::BountyHasNoAssignee,
+        ContractError::RewardMustBePositive,
+        ContractError::RewardBelowMinimum,
+        ContractError::NotBountyCreator,
+        ContractError::VerifierCannotBeAssignee,
+        ContractError::CreatorCannotClaim,
+        ContractError::ContributorHasActiveClaim,
+        ContractError::BountyIsDisputed,
+        ContractError::BountyDeadlinePassed,
+        ContractError::BountyNoDeadline,
+        ContractError::DeadlineNotPassed,
+        ContractError::ReputationTooLow,
+        ContractError::TooManyTags,
+        ContractError::MaxAssigneesMustBePositive,
+        ContractError::OnlyCreatorOrAssigneeCanDispute,
+        ContractError::VerifierNotAuthorized,
+        ContractError::AlreadyApproved,
+        ContractError::BountyNotDisputed,
+        ContractError::NotArbitrator,
+        ContractError::ApprovalThresholdExceedsVerifiers,
+        ContractError::InvalidRewardToken,
+        ContractError::MilestoneAlreadyCompleted,
+        ContractError::NotAllMilestonesCompleted,
+        ContractError::InvalidMilestoneIndex,
+        ContractError::MilestoneRewardsMismatch,
+    ];
+
+    for (i, left) in variants.iter().enumerate() {
+        for right in variants.iter().skip(i + 1) {
+            assert_ne!(
+                message(*left),
+                message(*right),
+                "duplicate ContractError message between variants"
+            );
+        }
+    }
+}
+
+/// create_bounty rejects non-token reward_token addresses (issue #649).
+#[test]
+#[should_panic(expected = "invalid reward_token address")]
+fn test_create_bounty_rejects_invalid_reward_token() {
+    let (env, creator, _contributor, _verifier) = setup_test();
+    let contract_id = env.register(MergeMintContract, ());
+    let client = MergeMintContractClient::new(&env, &contract_id);
+
+    client.create_bounty(
+        &creator,
+        &Symbol::new(&env, "bad_token"),
+        &String::from_str(&env, "desc"),
+        &1000,
+        &Address::generate(&env),
+        &0,
+        &None,
+        &Vec::new(&env),
+        &1,
+        &None,
+        &1,
+        &Vec::new(&env),
+    );
 }
 
 /// ContractError::TooManyTags is wired to the correct panic message.


### PR DESCRIPTION
## Summary
Fixes #649

### Changes Implemented
- Audited all 29 `ContractError` variants — `InvalidRewardToken` was dead code; now enforced in `create_bounty` via non-trapping `balance` probe (`validate_reward_token`).
- Extended `test_contract_error_messages` to cover every variant including milestones/reward guards.
- Added `test_contract_error_messages_are_unique` pairwise uniqueness regression.
- Added `test_create_bounty_rejects_invalid_reward_token` should-panic coverage.

### Verification
- `cargo test` — 70/70 passed
- `cargo clippy --all-targets -- -D warnings` — clean

### Payout Settlement
- **Wallet**: `0xbf10d7ef874044c5a48074c049b5d23b57087537`