### PR TITLE
feat(sdk): retry/backoff, JSDoc, and CI gates for the TypeScript SDK

### DIFF
--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -2,13 +2,15 @@
 #
 # CI pipeline for the TypeScript SDK (`sdk/`).
 #
-# Implements issue #667 — "add a `tsc --noEmit` gate for `sdk/` to CI". Before
-# this workflow only the Rust jobs were gated, so a type error in `sdk/` could
-# land on `main` unnoticed.
+# Implements issue #667 — "add a `tsc --noEmit` gate for `sdk/` to CI" — and
+# issue #664 — "add a CI check that `sdk/` version bumps are reflected in
+# `CHANGELOG.md`". Before this workflow only the Rust jobs were gated, so a
+# type error in `sdk/` could land on `main` unnoticed.
 #
 # Jobs:
 #   typecheck  — `tsc --noEmit` over `sdk/src`
 #   test       — the sdk package's jest suite
+#   changelog  — a version bump in `sdk/package.json` must ship a CHANGELOG entry
 #
 # All jobs are scoped to changes under `sdk/` so they do not fire on unrelated
 # commits.
@@ -24,6 +26,7 @@ on:
   pull_request:
     paths:
       - "sdk/**"
+      - "CHANGELOG.md"
       - ".github/workflows/sdk-ci.yml"
 
 jobs:
@@ -72,3 +75,50 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+  # --------------------------------------------------------------------------
+  # 3. Changelog gate
+  # --------------------------------------------------------------------------
+  #
+  # A release is only discoverable if the version bump is documented, so when a
+  # PR changes the `version` field of `sdk/package.json` it must also touch
+  # `CHANGELOG.md`. PRs that leave the version alone are unaffected.
+  changelog:
+    name: Changelog entry for version bump
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require a CHANGELOG entry when sdk/package.json version changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # A brand-new sdk/package.json has no base revision; treat that as "no version".
+          base_json=$(git show "$BASE_SHA:sdk/package.json" 2>/dev/null || echo '{}')
+          base_version=$(printf '%s' "$base_json" \
+            | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{try{console.log(JSON.parse(s).version??"")}catch{console.log("")}})')
+          head_version=$(node -p 'require("./sdk/package.json").version')
+
+          echo "base sdk version: ${base_version:-<none>}"
+          echo "head sdk version: $head_version"
+
+          if [ "$base_version" = "$head_version" ]; then
+            echo "✓ sdk/package.json version unchanged — no CHANGELOG entry required"
+            exit 0
+          fi
+
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -qx 'CHANGELOG.md'; then
+            echo "✓ sdk version bumped to $head_version and CHANGELOG.md was updated"
+            exit 0
+          fi
+
+          echo "✗ sdk/package.json version changed (${base_version:-<none>} -> $head_version) but CHANGELOG.md was not updated."
+          echo ""
+          echo "Add an entry describing the release under the appropriate heading in CHANGELOG.md."
+          exit 1

--- a/.github/workflows/sdk-ci.yml
+++ b/.github/workflows/sdk-ci.yml
@@ -1,0 +1,74 @@
+# .github/workflows/sdk-ci.yml
+#
+# CI pipeline for the TypeScript SDK (`sdk/`).
+#
+# Implements issue #667 — "add a `tsc --noEmit` gate for `sdk/` to CI". Before
+# this workflow only the Rust jobs were gated, so a type error in `sdk/` could
+# land on `main` unnoticed.
+#
+# Jobs:
+#   typecheck  — `tsc --noEmit` over `sdk/src`
+#   test       — the sdk package's jest suite
+#
+# All jobs are scoped to changes under `sdk/` so they do not fire on unrelated
+# commits.
+
+name: SDK CI
+
+on:
+  push:
+    branches: [main, "feat/**", "fix/**", "docs/**", "ci/**"]
+    paths:
+      - "sdk/**"
+      - ".github/workflows/sdk-ci.yml"
+  pull_request:
+    paths:
+      - "sdk/**"
+      - ".github/workflows/sdk-ci.yml"
+
+jobs:
+  # --------------------------------------------------------------------------
+  # 1. Typecheck
+  # --------------------------------------------------------------------------
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Typecheck (tsc --noEmit)
+        run: npm run typecheck
+
+  # --------------------------------------------------------------------------
+  # 2. Tests
+  # --------------------------------------------------------------------------
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: sdk
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run tests
+        run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 Changes that have landed on `main` but are not yet associated with a tagged release.
 
+### Added
+
+- `sdk`: optional `retry: { attempts, backoffMs }` constructor option that retries
+  every Soroban RPC round-trip with exponential backoff (#665).
+- `sdk`: JSDoc on every public `MergeMintSDK` method, documenting parameters,
+  return values, and thrown errors (#663).
+- CI: `SDK CI` workflow gating `sdk/` on `tsc --noEmit` and the jest suite (#667).
+- CI: `SDK CI` job requiring a `CHANGELOG.md` entry whenever `sdk/package.json`
+  changes version (#664).
+
+### Fixed
+
+- `sdk`: removed an orphaned `CreateBountyParams` fragment left in
+  `sdk/src/index.ts` by an earlier merge, which made the module unparseable.
+
 ---
 
 ## [0.1.0] — 2024-01-01

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -118,6 +118,26 @@ const sdk = new MergeMintSDK({
 });
 ```
 
+## Retries
+
+Transient RPC failures — a dropped connection, a provider rate limit — surface
+directly to the caller by default. Pass `retry` to have every RPC round-trip
+retried with exponential backoff:
+
+```ts
+const sdk = new MergeMintSDK({
+  ...TESTNET,
+  contractId: "C...",
+  retry: { attempts: 3, backoffMs: 200 },
+});
+```
+
+`attempts` counts the first call, so `3` means one call plus two retries.
+`backoffMs` is the base delay and doubles after each failed attempt (200ms, then
+400ms). Omitting `retry` keeps the previous single-attempt behaviour. The
+constructor throws if `attempts` is not an integer `>= 1` or `backoffMs` is
+negative.
+
 ## Bounty ID format
 
 Bounty IDs are 32-byte values returned from `createBounty` and stored on-chain. The SDK represents them as lowercase hex strings (64 characters). Pass them directly to any method that accepts a `bountyId`.

--- a/sdk/jest.config.js
+++ b/sdk/jest.config.js
@@ -1,0 +1,7 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+  roots: ["<rootDir>/src"],
+  testMatch: ["**/*.test.ts"],
+};

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -6,12 +6,17 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "jest"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^12.0.0"
   },
   "devDependencies": {
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.12.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
     "typescript": "^5.4.0"
   },
   "files": [

--- a/sdk/src/index.test.ts
+++ b/sdk/src/index.test.ts
@@ -1,4 +1,5 @@
-import { symbolToScVal } from "./index";
+import { nativeToScVal } from "@stellar/stellar-sdk";
+import { MergeMintSDK, symbolToScVal, TESTNET } from "./index";
 
 describe("symbolToScVal", () => {
   it("throws for a 33-character input", () => {
@@ -11,5 +12,95 @@ describe("symbolToScVal", () => {
   it("passes for exactly 32 characters", () => {
     const value = "a".repeat(32);
     expect(() => symbolToScVal(value)).not.toThrow();
+  });
+});
+
+const CONTRACT_ID = "CA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ";
+
+/**
+ * Minimal stand-in for `SorobanRpc.Server`. `getAccount` fails for the first
+ * `failures` calls and succeeds afterwards, so a test can assert that the retry
+ * policy recovers from a transient hiccup.
+ */
+function makeFlakyRpc(failures: number, retval = 7n) {
+  const calls = { getAccount: 0, simulateTransaction: 0 };
+  return {
+    calls,
+    getAccount: jest.fn(async () => {
+      calls.getAccount++;
+      if (calls.getAccount <= failures) {
+        throw new Error("transient RPC failure");
+      }
+      return {
+        accountId: () => CONTRACT_ID,
+        sequenceNumber: () => "1",
+        incrementSequenceNumber: () => undefined,
+      };
+    }),
+    simulateTransaction: jest.fn(async () => {
+      calls.simulateTransaction++;
+      return { result: { retval: nativeToScVal(retval, { type: "i128" }) } };
+    }),
+  };
+}
+
+function sdkWithRpc(
+  rpc: unknown,
+  retry?: { attempts: number; backoffMs: number },
+) {
+  const sdk = new MergeMintSDK({
+    ...TESTNET,
+    contractId: CONTRACT_ID,
+    retry,
+  });
+  // The SDK builds its own `SorobanRpc.Server` from `rpcUrl`; swap in the stub.
+  (sdk as unknown as { rpc: unknown }).rpc = rpc;
+  return sdk;
+}
+
+describe("MergeMintSDK retry", () => {
+  it("recovers when an RPC call fails once then succeeds", async () => {
+    const rpc = makeFlakyRpc(1);
+    const sdk = sdkWithRpc(rpc, { attempts: 3, backoffMs: 0 });
+
+    await expect(sdk.getBountyCount()).resolves.toBe(7n);
+    expect(rpc.calls.getAccount).toBe(2);
+  });
+
+  it("makes a single attempt when no retry option is supplied", async () => {
+    const rpc = makeFlakyRpc(1);
+    const sdk = sdkWithRpc(rpc);
+
+    await expect(sdk.getBountyCount()).resolves.toBe(0n);
+    expect(rpc.calls.getAccount).toBe(1);
+  });
+
+  it("gives up and surfaces the last error once attempts are exhausted", async () => {
+    const rpc = makeFlakyRpc(5);
+    const sdk = sdkWithRpc(rpc, { attempts: 2, backoffMs: 0 });
+
+    // `getBountyCount` swallows the failure and yields the zero-value default.
+    await expect(sdk.getBountyCount()).resolves.toBe(0n);
+    expect(rpc.calls.getAccount).toBe(2);
+  });
+
+  it("rejects an out-of-range retry configuration", () => {
+    expect(
+      () =>
+        new MergeMintSDK({
+          ...TESTNET,
+          contractId: CONTRACT_ID,
+          retry: { attempts: 0, backoffMs: 10 },
+        }),
+    ).toThrow(/Invalid retry.attempts/);
+
+    expect(
+      () =>
+        new MergeMintSDK({
+          ...TESTNET,
+          contractId: CONTRACT_ID,
+          retry: { attempts: 2, backoffMs: -1 },
+        }),
+    ).toThrow(/Invalid retry.backoffMs/);
   });
 });

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -194,6 +194,17 @@ export class MergeMintSDK {
   private readonly contractId: string;
   private readonly retry: RetryOptions;
 
+  /**
+   * Creates an SDK bound to a single Soroban RPC endpoint and contract.
+   *
+   * @param config - Network configuration. `rpcUrl` must be a real provider
+   * endpoint, `contractId` the deployed MergeMint contract, and
+   * `networkPassphrase` the passphrase of the target network (see {@link TESTNET}
+   * and {@link MAINNET}). Pass `retry` to make every RPC round-trip tolerate
+   * transient failures — see {@link RetryOptions}.
+   * @throws Error if `rpcUrl` still contains a placeholder, or if `retry` holds
+   * an out-of-range `attempts` or `backoffMs`.
+   */
   constructor(config: NetworkConfig) {
     if (config.rpcUrl.includes("XCa...") || config.rpcUrl.includes("...")) {
       throw new Error("Invalid RPC URL: placeholder detected in configuration. Please provide a valid Soroban RPC provider URL.");
@@ -207,6 +218,15 @@ export class MergeMintSDK {
 
   // === Read methods (no transaction needed)
 
+  /**
+   * Reads a single bounty by id.
+   *
+   * @param bountyId - Bounty id as a hex-encoded `BytesN<32>` string.
+   * @returns The decoded {@link Bounty}, or `null` when the contract account is
+   * unreachable, the simulation errors, or no bounty exists for that id.
+   * @throws Error if `bountyId` is not valid hex, or if the RPC transport fails
+   * on every attempt allowed by the configured retry policy.
+   */
   async getBounty(bountyId: string): Promise<Bounty | null> {
     const result = await this.simulateReadCall("get_bounty", [
       hexToBytesN(bountyId),
@@ -215,6 +235,15 @@ export class MergeMintSDK {
     return parseBounty(scValToNative(result));
   }
 
+  /**
+   * Reads the off-chain-facing title and description stored for a bounty.
+   *
+   * @param bountyId - Bounty id as a hex-encoded `BytesN<32>` string.
+   * @returns The {@link BountyMeta}, or `null` when the contract account is
+   * unreachable, the simulation errors, or no metadata exists for that id.
+   * @throws Error if `bountyId` is not valid hex, or if the RPC transport fails
+   * on every attempt allowed by the configured retry policy.
+   */
   async getBountyMeta(bountyId: string): Promise<BountyMeta | null> {
     const result = await this.simulateReadCall("get_bounty_meta", [
       hexToBytesN(bountyId),
@@ -224,6 +253,15 @@ export class MergeMintSDK {
     return { title: raw.title, description: raw.description };
   }
 
+  /**
+   * Reads a contributor's on-chain reputation record.
+   *
+   * @param address - Stellar account address (`G...`) or contract address (`C...`).
+   * @returns The decoded {@link Contributor}, or `null` when the contract account
+   * is unreachable, the simulation errors, or the address has no record.
+   * @throws Error if `address` is not a valid Stellar address, or if the RPC
+   * transport fails on every attempt allowed by the configured retry policy.
+   */
   async getContributor(address: string): Promise<Contributor | null> {
     const result = await this.simulateReadCall("get_contributor", [
       addressToScVal(address),
@@ -232,12 +270,28 @@ export class MergeMintSDK {
     return parseContributor(scValToNative(result));
   }
 
+  /**
+   * Reads the total number of bounties ever created by the contract.
+   *
+   * @returns The count as a `bigint`; `0n` when the contract account is
+   * unreachable or the simulation errors.
+   * @throws Error if the RPC transport fails on every attempt allowed by the
+   * configured retry policy.
+   */
   async getBountyCount(): Promise<bigint> {
     const result = await this.simulateReadCall("get_bounty_count", []);
     if (!result) return 0n;
     return BigInt(scValToNative(result) as string | number | bigint);
   }
 
+  /**
+   * Reads the ids of every bounty currently in the `open` state.
+   *
+   * @returns Bounty ids as hex-encoded strings; an empty array when the contract
+   * account is unreachable or the simulation errors.
+   * @throws Error if the RPC transport fails on every attempt allowed by the
+   * configured retry policy.
+   */
   async getOpenBounties(): Promise<string[]> {
     const result = await this.simulateReadCall("get_open_bounties", []);
     if (!result) return [];
@@ -247,6 +301,21 @@ export class MergeMintSDK {
 
   // === Write methods (return assembled transaction XDR for signing)
 
+  /**
+   * Builds a `create_bounty` transaction. The transaction is simulated and
+   * assembled but **not** signed or submitted — sign the returned XDR and submit
+   * it yourself.
+   *
+   * @param params - Bounty definition; see {@link CreateBountyParams}. `deadline`
+   * and `requiredVerifiers` are optional, `approvalThreshold` defaults to `1`
+   * and `milestones` defaults to an empty list.
+   * @param sourceAccount - Address that funds and signs the transaction.
+   * @returns The assembled transaction as a base64 XDR string.
+   * @throws Error if `params.title`, `params.description` or any milestone
+   * description exceeds the 32-character `Symbol` limit; if an address is
+   * invalid; if `sourceAccount` does not exist on the network; or if the
+   * simulation fails (message prefixed `Simulation failed:`).
+   */
   async createBounty(
     params: CreateBountyParams,
     sourceAccount: string
@@ -268,6 +337,19 @@ export class MergeMintSDK {
     return this.buildTransaction("create_bounty", args, sourceAccount);
   }
 
+  /**
+   * Builds a `claim_bounty` transaction assigning a contributor to an open
+   * bounty. Not signed or submitted.
+   *
+   * @param contributor - Address of the claiming contributor.
+   * @param bountyId - Bounty id as a hex-encoded `BytesN<32>` string.
+   * @param sourceAccount - Address that funds and signs the transaction.
+   * @returns The assembled transaction as a base64 XDR string.
+   * @throws Error if an address or `bountyId` is invalid, if `sourceAccount`
+   * does not exist on the network, or if the simulation fails — including when
+   * the contract rejects the claim for insufficient reputation, a passed
+   * deadline, or a full assignee list (message prefixed `Simulation failed:`).
+   */
   async claimBounty(
     contributor: string,
     bountyId: string,
@@ -277,6 +359,19 @@ export class MergeMintSDK {
     return this.buildTransaction("claim_bounty", args, sourceAccount);
   }
 
+  /**
+   * Builds a `complete_bounty` transaction, which distributes the reward to the
+   * assignees by basis-point share. Not signed or submitted.
+   *
+   * @param verifier - Address attesting that the work is complete.
+   * @param bountyId - Bounty id as a hex-encoded `BytesN<32>` string.
+   * @param sourceAccount - Address that funds and signs the transaction.
+   * @returns The assembled transaction as a base64 XDR string.
+   * @throws Error if an address or `bountyId` is invalid, if `sourceAccount`
+   * does not exist on the network, or if the simulation fails — including when
+   * the contract rejects the caller as an unauthorised verifier (message
+   * prefixed `Simulation failed:`).
+   */
   async completeBounty(
     verifier: string,
     bountyId: string,
@@ -286,6 +381,19 @@ export class MergeMintSDK {
     return this.buildTransaction("complete_bounty", args, sourceAccount);
   }
 
+  /**
+   * Builds an `approve_completion` transaction recording one verifier approval
+   * toward the bounty's `approvalThreshold`. Not signed or submitted.
+   *
+   * @param verifier - Address casting the approval.
+   * @param bountyId - Bounty id as a hex-encoded `BytesN<32>` string.
+   * @param sourceAccount - Address that funds and signs the transaction.
+   * @returns The assembled transaction as a base64 XDR string.
+   * @throws Error if an address or `bountyId` is invalid, if `sourceAccount`
+   * does not exist on the network, or if the simulation fails — including when
+   * the verifier is not in `requiredVerifiers` or has already approved (message
+   * prefixed `Simulation failed:`).
+   */
   async approveCompletion(
     verifier: string,
     bountyId: string,
@@ -295,6 +403,21 @@ export class MergeMintSDK {
     return this.buildTransaction("approve_completion", args, sourceAccount);
   }
 
+  /**
+   * Builds a `resolve_dispute` transaction settling a disputed bounty. Not
+   * signed or submitted.
+   *
+   * @param arbitrator - Address authorised to resolve the dispute.
+   * @param bountyId - Bounty id as a hex-encoded `BytesN<32>` string.
+   * @param resolution - `"complete"` pays the assignees; `"cancel"` refunds the
+   * creator.
+   * @param sourceAccount - Address that funds and signs the transaction.
+   * @returns The assembled transaction as a base64 XDR string.
+   * @throws Error if an address or `bountyId` is invalid, if `sourceAccount`
+   * does not exist on the network, or if the simulation fails — including when
+   * the bounty is not in the `disputed` state (message prefixed
+   * `Simulation failed:`).
+   */
   async resolveDispute(
     arbitrator: string,
     bountyId: string,

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -24,13 +24,6 @@ export const MAINNET: Omit<NetworkConfig, "contractId"> = {
   rpcUrl: "https://mainnet.stellar.validationcloud.io/v1/XCa...",
   networkPassphrase: Networks.PUBLIC,
 };
-  rewardToken: string;
-  minReputation: number;
-  deadline: number | null;
-  tags: string[];
-  requiredVerifiers?: string[];
-  approvalThreshold?: number;
-}
 
 // === Helpers
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -11,7 +11,14 @@ import {
 } from "@stellar/stellar-sdk";
 
 export * from "./types";
-import { NetworkConfig, Bounty, BountyMeta, Contributor, CreateBountyParams } from "./types";
+import {
+  NetworkConfig,
+  Bounty,
+  BountyMeta,
+  Contributor,
+  CreateBountyParams,
+  RetryOptions,
+} from "./types";
 
 export const TESTNET: Omit<NetworkConfig, "contractId"> = {
   rpcUrl: "https://soroban-testnet.stellar.org",
@@ -31,7 +38,7 @@ function addressToScVal(address: string): xdr.ScVal {
   return new Address(address).toScVal();
 }
 
-function symbolToScVal(value: string): xdr.ScVal {
+export function symbolToScVal(value: string): xdr.ScVal {
   if (value.length > 32) {
     throw new Error(`value exceeds 32-character Symbol limit: ${value}`);
   }
@@ -154,6 +161,30 @@ function parseContributor(raw: unknown): Contributor {
   };
 }
 
+// === Retry
+
+const NO_RETRY: RetryOptions = { attempts: 1, backoffMs: 0 };
+
+function normalizeRetry(retry: RetryOptions | undefined): RetryOptions {
+  if (!retry) return NO_RETRY;
+  if (!Number.isInteger(retry.attempts) || retry.attempts < 1) {
+    throw new Error(
+      `Invalid retry.attempts: expected an integer >= 1, got ${retry.attempts}`
+    );
+  }
+  if (!Number.isFinite(retry.backoffMs) || retry.backoffMs < 0) {
+    throw new Error(
+      `Invalid retry.backoffMs: expected a number >= 0, got ${retry.backoffMs}`
+    );
+  }
+  return { attempts: retry.attempts, backoffMs: retry.backoffMs };
+}
+
+function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 // === SDK
 
 export class MergeMintSDK {
@@ -161,6 +192,7 @@ export class MergeMintSDK {
   private readonly contract: Contract;
   private readonly networkPassphrase: string;
   private readonly contractId: string;
+  private readonly retry: RetryOptions;
 
   constructor(config: NetworkConfig) {
     if (config.rpcUrl.includes("XCa...") || config.rpcUrl.includes("...")) {
@@ -170,6 +202,7 @@ export class MergeMintSDK {
     this.contract = new Contract(config.contractId);
     this.networkPassphrase = config.networkPassphrase;
     this.contractId = config.contractId;
+    this.retry = normalizeRetry(config.retry);
   }
 
   // === Read methods (no transaction needed)
@@ -278,11 +311,36 @@ export class MergeMintSDK {
 
   // === Internals
 
+  /**
+   * Runs a single RPC round-trip under the configured retry policy, doubling the
+   * backoff after every failed attempt. Rethrows the last error once the
+   * attempt budget is exhausted.
+   */
+  private async withRetry<T>(operation: () => Promise<T>): Promise<T> {
+    const { attempts, backoffMs } = this.retry;
+    let lastError: unknown;
+
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      try {
+        return await operation();
+      } catch (err) {
+        lastError = err;
+        if (attempt < attempts - 1) {
+          await sleep(backoffMs * 2 ** attempt);
+        }
+      }
+    }
+
+    throw lastError;
+  }
+
   private async simulateReadCall(
     method: string,
     args: xdr.ScVal[]
   ): Promise<xdr.ScVal | null> {
-    const account = await this.rpc.getAccount(this.contractId).catch(() => null);
+    const account = await this.withRetry(() =>
+      this.rpc.getAccount(this.contractId)
+    ).catch(() => null);
     if (!account) return null;
 
     const tx = new TransactionBuilder(account, {
@@ -293,7 +351,7 @@ export class MergeMintSDK {
       .setTimeout(30)
       .build();
 
-    const sim = await this.rpc.simulateTransaction(tx);
+    const sim = await this.withRetry(() => this.rpc.simulateTransaction(tx));
     if (SorobanRpc.Api.isSimulationError(sim)) return null;
 
     const result = (sim as SorobanRpc.Api.SimulateTransactionSuccessResponse)
@@ -306,7 +364,9 @@ export class MergeMintSDK {
     args: xdr.ScVal[],
     sourceAccount: string
   ): Promise<string> {
-    const account = await this.rpc.getAccount(sourceAccount);
+    const account = await this.withRetry(() =>
+      this.rpc.getAccount(sourceAccount)
+    );
     const tx = new TransactionBuilder(account, {
       fee: BASE_FEE,
       networkPassphrase: this.networkPassphrase,
@@ -315,7 +375,7 @@ export class MergeMintSDK {
       .setTimeout(30)
       .build();
 
-    const sim = await this.rpc.simulateTransaction(tx);
+    const sim = await this.withRetry(() => this.rpc.simulateTransaction(tx));
     if (SorobanRpc.Api.isSimulationError(sim)) {
       throw new Error(`Simulation failed: ${sim.error}`);
     }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -1,7 +1,19 @@
+export interface RetryOptions {
+  /** Total number of attempts, including the first one. Must be >= 1. */
+  attempts: number;
+  /** Base delay in milliseconds; doubled after every failed attempt. Must be >= 0. */
+  backoffMs: number;
+}
+
 export interface NetworkConfig {
   rpcUrl: string;
   networkPassphrase: string;
   contractId: string;
+  /**
+   * Optional retry policy applied to every Soroban RPC round-trip. Omitted
+   * means a single attempt with no backoff, matching the previous behaviour.
+   */
+  retry?: RetryOptions;
 }
 
 export interface Bounty {


### PR DESCRIPTION
Bundles the four SDK issues assigned to me in the Stellar Wave Program. Each lands as its own commit so they can be reviewed — or reverted — independently.

Closes #663
Closes #664
Closes #665
Closes #667

---

### #663 — JSDoc on every public `MergeMintSDK` method

`MergeMintSDK` methods carried no JSDoc, so consumers got no inline documentation in their editor.

Added a block above the constructor and each of the ten public methods describing every parameter, the return value — including what `null` and the zero-value defaults mean on the read path — and the errors each can throw: invalid addresses and hex ids, the 32-character `Symbol` limit, and the `Simulation failed:` wrapper on the write path.

Documentation only; no behaviour change.

### #665 — Configurable retry/backoff on SDK RPC calls

There was no retry behaviour, so a transient Soroban RPC hiccup — a dropped connection, a provider rate limit — surfaced straight to the caller.

`NetworkConfig` gains an optional `retry: { attempts, backoffMs }`. Every RPC round-trip (`getAccount`, `simulateTransaction`, on both the read and write paths) now goes through a private `withRetry` helper that doubles the backoff after each failed attempt and rethrows the last error once the budget is spent. Omitting `retry` keeps the previous single-attempt behaviour exactly.

The constructor validates the policy up front, rejecting a non-integer or sub-1 `attempts` and a negative `backoffMs`.

```ts
const sdk = new MergeMintSDK({
  ...TESTNET,
  contractId: "C...",
  retry: { attempts: 3, backoffMs: 200 },
});
```

### #667 — `tsc --noEmit` gate for `sdk/`

Nothing in `.github/workflows/` typechecked `sdk/` — only the Rust jobs were gated — so a TypeScript error could land on `main` unnoticed.

New `sdk-ci.yml` with a `typecheck` job running the package's existing `npm run typecheck` and a `test` job running its jest suite. Both are `paths`-scoped to `sdk/**` and the workflow itself, matching how `backend-ci.yml` scopes its Rust jobs.

### #664 — Changelog entry required on an SDK version bump

Nothing checked that a version bump in `sdk/package.json` shipped with a `CHANGELOG.md` entry, so a release could go out undocumented.

A `changelog` job compares the `version` field between the PR base and head. Unchanged, it passes immediately. Changed, it requires `CHANGELOG.md` in the same PR's diff and fails with the old and new versions in the log otherwise. A newly added `sdk/package.json` is handled as "no base version".

---

### Two things reviewers should look at

**A pre-existing syntax error had to be fixed first** (commit 1). `sdk/src/index.ts` carried an orphaned tail of a `CreateBountyParams` interface stranded after the `MAINNET` constant by an earlier merge, which made the module unparseable. The interface already lives in `sdk/src/types.ts`, so the remnant is simply removed. Without this the #667 typecheck gate is red on arrival, and #663's "confirm the sdk still builds with `tsc`" cannot hold.

**The sdk had no test runner.** `sdk/package.json` had no `test` script, but #663 asks for `npm test` inside `sdk/` and #665 asks for a unit test with a mocked RPC client. Added `jest`, `ts-jest`, `@types/jest` and `@types/node` as devDependencies plus a `jest.config.js`. `@types/node` is also required for the typecheck gate to pass — `index.ts` uses `Buffer`.

### Testing

Per the constraints I was working under, I did not run the build or test suites in this branch — no `npm install`, `tsc` or `jest` was executed. The retry tests use a stub RPC client that fails a set number of times before succeeding, covering recovery after one failure, the single-attempt default, exhaustion of the attempt budget, and the constructor validation. `symbolToScVal` is now exported, which the pre-existing `index.test.ts` already assumed.

Please confirm CI green before merging.
