### PR TITLE
feat(backend): rate-limit the self_claim route (#670)

### DIFF
--- a/mergemint-backend/src/main.rs
+++ b/mergemint-backend/src/main.rs
@@ -52,7 +52,7 @@ mod db;
 mod routes;
 
 use db::{new_shared_db, new_shared_idempotency_store};
-use routes::tx::{resolve_dispute, self_claim, AppState};
+use routes::tx::{resolve_dispute, self_claim, AppState, new_shared_rate_limiter};
 
 /// Maximum allowed request body size (1 MiB).
 const MAX_BODY_BYTES: usize = 1024 * 1024;
@@ -97,6 +97,7 @@ async fn main() {
     let state = Arc::new(AppState {
         db: shared_db,
         idempotency,
+        rate_limiter: new_shared_rate_limiter(),
     });
 
     let app = Router::new()

--- a/mergemint-backend/src/routes/tx.rs
+++ b/mergemint-backend/src/routes/tx.rs
@@ -9,7 +9,9 @@ use axum::{
     Json,
 };
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::db::{
     acquire_idempotency, read_db, read_idempotency, IdempotencyEntry, SharedDb,
@@ -23,6 +25,58 @@ use crate::db::{
 pub struct AppState {
     pub db: SharedDb,
     pub idempotency: SharedIdempotencyStore,
+    /// In-memory fixed-window rate limiter for expensive, on-chain-submitting
+    /// routes such as `self_claim` (issue #670). Keyed by an opaque client
+    /// identifier (the claimant address). A production deployment should back
+    /// this with a shared store (Redis) so the limit holds across replicas;
+    /// the in-process map is sufficient for a single-instance stub backend.
+    pub rate_limiter: SharedRateLimiter,
+}
+
+/// Maximum `self_claim` calls allowed per [`SELF_CLAIM_RATE_WINDOW_SECS`] window,
+/// per claimant.
+const SELF_CLAIM_RATE_LIMIT: u32 = 10;
+/// Sliding-reset window length (seconds) for the `self_claim` rate limiter.
+const SELF_CLAIM_RATE_WINDOW_SECS: u64 = 60;
+
+struct RateBucket {
+    count: u32,
+    window_start: u64,
+}
+
+pub type SharedRateLimiter = Arc<Mutex<HashMap<String, RateBucket>>>;
+
+/// Construct a new in-process rate-limiter handle.
+pub fn new_shared_rate_limiter() -> SharedRateLimiter {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+
+impl AppState {
+    /// Fixed-window rate limiter for `self_claim`, keyed by `key` (the claimant
+    /// address). Returns `true` if the request is allowed, `false` if the limit
+    /// for the current window is already exhausted.
+    pub fn allow_self_claim(&self, key: &str) -> bool {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        let mut buckets = self.rate_limiter.lock().unwrap();
+        let bucket = buckets
+            .entry(key.to_string())
+            .or_insert(RateBucket {
+                count: 0,
+                window_start: now,
+            });
+        if now.saturating_sub(bucket.window_start) >= SELF_CLAIM_RATE_WINDOW_SECS {
+            bucket.window_start = now;
+            bucket.count = 0;
+        }
+        if bucket.count >= SELF_CLAIM_RATE_LIMIT {
+            return false;
+        }
+        bucket.count += 1;
+        true
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -158,6 +212,14 @@ impl AppError {
             message: msg.into(),
         };
         (StatusCode::NOT_FOUND, Json(err))
+    }
+
+    pub fn too_many_requests(msg: impl Into<String>) -> (StatusCode, Json<AppError>) {
+        let err = AppError {
+            code: 429,
+            message: msg.into(),
+        };
+        (StatusCode::TOO_MANY_REQUESTS, Json(err))
     }
 
     /// Construct an internal server error.
@@ -327,6 +389,15 @@ pub async fn self_claim(
             return Ok(response)
         }
     };
+
+    // Rate-limit expensive on-chain-submitting routes (#670). Keyed by the
+    // claimant so one user cannot hammer `self_claim`; a 429 is returned once
+    // the per-window allowance is exhausted.
+    if !state.allow_self_claim(&req.claimant) {
+        return Err(AppError::too_many_requests(
+            "rate limit exceeded for self_claim; retry after the window resets",
+        ));
+    }
 
     let result = self_claim_inner(&state, &req).await;
 


### PR DESCRIPTION
# Rate-limit the `self_claim` route (#670)

## Summary

Closes #670

`self_claim` submits an on-chain transaction (it builds and sends a Stellar
operation). Without a limiter a single client could hammer the endpoint and
waste Horizon/RPC capacity or grief the bounty contract. This adds a fixed-window
in-memory rate limiter to `AppState`, keyed by the claimant address.

## What changed (`mergemint-backend/`)

- `AppState` gains a `rate_limiter: SharedRateLimiter` (an `Arc<Mutex<HashMap<…>>>`),
  constructed via `new_shared_rate_limiter()`.
- `AppState::allow_self_claim(key)` enforces `SELF_CLAIM_RATE_LIMIT` (10) calls per
  `SELF_CLAIM_RATE_WINDOW_SECS` (60s) per claimant, returning `false` once the
  window is exhausted.
- The `self_claim` handler now returns `429 Too Many Requests`
  (`AppError::too_many_requests`, code 429 added) when the limit is hit, *before*
  any on-chain work.
- `src/main.rs` wires the limiter into the `AppState` and imports the constructor.

## Notes

The limiter is in-process, so the limit is per-instance. For multi-replica
deployments this should be backed by a shared store (e.g. Redis); the interface
is intentionally small so swapping the backing is a localized change. It does not
affect `resolve_dispute`. Existing tests call `self_claim` once per window, so
they remain within the limit.

closes #670
