### PR TITLE
fix: debounced validation, disconnected empty state, and mobile layout coverage

### DIFF
--- a/frontend/e2e/bounty-list-responsive.spec.ts
+++ b/frontend/e2e/bounty-list-responsive.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Confirms the bounty card grid on BountyList reflows to a single column at
+ * mobile widths, rather than staying in a multi-column layout.
+ *
+ * Requires a local dev server (or mocked backend) reachable at baseURL with
+ * at least two bounties returned, matching the setup used by happy-path.spec.ts.
+ */
+test.use({ viewport: { width: 375, height: 812 } });
+
+test("bounty card grid stacks to a single column on mobile", async ({ page }) => {
+  await page.goto("/");
+
+  const cards = page.locator(".bounty-grid > *");
+  const count = await cards.count();
+  test.skip(count < 2, "Needs at least two bounties to assert stacking.");
+
+  const boxes = await Promise.all(
+    Array.from({ length: count }, (_, i) => cards.nth(i).boundingBox())
+  );
+
+  for (let i = 1; i < boxes.length; i++) {
+    expect(boxes[i]!.x).toBeCloseTo(boxes[0]!.x, 0);
+    expect(boxes[i]!.y).toBeGreaterThan(boxes[i - 1]!.y);
+  }
+});

--- a/frontend/src/components/CreateBounty.tsx
+++ b/frontend/src/components/CreateBounty.tsx
@@ -1,8 +1,16 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useTxFlow } from "../hooks/useTxFlow";
 import { TxResultBanner } from "./TxResultBanner";
 import { TxButton } from "./TxButton";
 import { NetworkName } from "../lib/types";
+
+const VALIDATION_DEBOUNCE_MS = 200;
+
+function validateForm(title: string, description: string): string | null {
+  if (title.trim() === "") return "Title is required.";
+  if (description.trim() === "") return "Description is required.";
+  return null;
+}
 
 interface CreateBountyProps {
   network: NetworkName;
@@ -24,7 +32,15 @@ export function CreateBounty({ network, onSubmit }: CreateBountyProps) {
   const [verifiers, setVerifiers] = useState<string[]>([""]);
   const [threshold, setThreshold] = useState(1);
   const [maxAssignees, setMaxAssignees] = useState(1);
+  const [validationError, setValidationError] = useState<string | null>(null);
   const { pending, error, result, run } = useTxFlow(network);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setValidationError(validateForm(title, description));
+    }, VALIDATION_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [title, description]);
 
   async function perform() {
     await run(() =>
@@ -115,6 +131,8 @@ export function CreateBounty({ network, onSubmit }: CreateBountyProps) {
           </select>
         </label>
       </details>
+
+      {validationError && <p className="error">{validationError}</p>}
 
       <TxButton type="submit" pending={pending} pendingLabel="Submitting…">
         Create bounty

--- a/frontend/src/pages/ContributorProfile.tsx
+++ b/frontend/src/pages/ContributorProfile.tsx
@@ -3,19 +3,25 @@ import { useParams } from 'react-router-dom';
 import { api } from '../lib/api';
 import { Contributor } from '../types';
 import { mapErrorMessage } from '../utils/format';
+import { useWallet } from '../lib/WalletContext';
 
 export function ContributorProfile() {
   const { address } = useParams<{ address: string }>();
+  const { address: walletAddress } = useWallet();
   const [contributor, setContributor] = useState<Contributor | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!address) return;
+    if (!address || !walletAddress) return;
     api
       .getContributor(address)
       .then(setContributor)
       .catch((err) => setError(mapErrorMessage(err instanceof Error ? err.message : String(err))));
-  }, [address]);
+  }, [address, walletAddress]);
+
+  if (!walletAddress) {
+    return <p className="contributor-profile__empty">Connect your wallet to view contributor profiles.</p>;
+  }
 
   if (error) return <p role="alert">{error}</p>;
   if (!contributor) return <p>Loading...</p>;


### PR DESCRIPTION
## Summary
- Debounce `CreateBounty`'s title/description validation (200ms) instead of recomputing on every keystroke
- Add a wallet-disconnected empty state to `ContributorProfile` so it no longer attempts to fetch profile data without a connected wallet
- Add a mobile-viewport e2e test (`frontend/e2e/bounty-list-responsive.spec.ts`) asserting `BountyList`'s card grid stacks to a single column
- Audited `frontend/src/components/*.tsx` for implicit `any` props (#696): all components already declare explicit prop types/interfaces (verified via `tsc --noEmit` under `strict` mode), so no source change was needed there

## Validation performed
- `tsc --noEmit` on `frontend/` shows no errors from the changed files (pre-existing `@types/babel__*`/`prop-types` resolution noise from a partial local install is unrelated to this change)
- `vitest`/`playwright` could not be run locally: `frontend/vite.config.ts` imports `@vitejs/plugin-react`, which is missing from `frontend/package.json` — a pre-existing, unrelated repo issue, documented here rather than fixed as part of this PR

Closes #694
Closes #696
Closes #697
Closes #698