### PR TITLE
Reconcile duplicate backend/ and mergemint-backend/ directories (#668)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,6 @@ Changes that have landed on `main` but are not yet associated with a tagged rele
 
 [Unreleased]: https://github.com/mergemint-mint/mergemint-contracts/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/mergemint-mint/mergemint-contracts/releases/tag/v0.1.0
+
+## [Unreleased]
+- Reconcile duplicate backend directories (#668): the orphaned TypeScript `backend/` (no Dockerfile, unreferenced by the build) has been removed; `docker-compose.yml` now builds the canonical Rust `mergemint-backend/`, and the doc reference in `docs/shared-type-generation.md` was updated.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   mergemint-backend:
     build:
-      context: ./backend
+      context: ./mergemint-backend
       dockerfile: Dockerfile
     ports:
       - "8080:8080"

--- a/docs/shared-type-generation.md
+++ b/docs/shared-type-generation.md
@@ -76,6 +76,6 @@ implementation; that topic remains undocumented.
   *different* shapes of `Bounty`/`Contributor` (e.g. `reward: string` vs.
   `rewardAmount: bigint`), neither of which imports from `sdk/src/types.ts`.
 - The original problem this doc set out to solve — a contract field rename
-  silently going out of sync with the backend/frontend/SDK — is therefore
+  silently going out of sync with the mergemint-backend/frontend/SDK — is therefore
   still open outside the SDK package itself. The codegen-from-Rust approach
   recommended above has not been attempted.


### PR DESCRIPTION
# Reconcile duplicate `backend/` and `mergemint-backend/` directories (#668)

## Summary

Closes #668

The repo carried two backend directories:

- `backend/` — a small, orphaned **TypeScript** stub (`health.ts`,
  `validateNetworkPassphrase.ts`, `health.test.ts`) with **no `Dockerfile`** and
  no reference from the build/CI.
- `mergemint-backend/` — the active **Rust** backend containing the real
  transaction/bounty logic (including `self_claim`, `resolve_dispute`, the db
  layer, and a `Dockerfile`).

`docker-compose.yml` defined a service named `mergemint-backend` but built
`context: ./backend` — which has no `Dockerfile`, so the compose build was broken.
This confirms `backend/` was the stale duplicate.

## What changed

- `docker-compose.yml`: `context` for the `mergemint-backend` service now points
  at `./mergemint-backend` (the canonical Rust backend that actually has a
  `Dockerfile`), fixing the broken build.
- Removed the orphaned `backend/` directory.
- `docs/shared-type-generation.md`: updated the one prose reference from
  `backend/frontend/SDK` to `mergemint-backend/frontend/SDK`.
- `CHANGELOG.md`: noted the reconciliation under Unreleased.

No application logic was changed; this is a structural de-duplication.

closes #668
