### PR TITLE
fix(sdk): add runtime validation that contractId is set in MergeMintSDK (#659)

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -170,13 +170,19 @@ export class MergeMintSDK {
   private readonly contractId: string;
 
   constructor(config: NetworkConfig) {
+    if (!config.contractId || typeof config.contractId !== "string" || config.contractId.trim() === "") {
+      throw new Error("Invalid contractId: contractId must be a non-empty string.");
+    }
+    if (config.contractId.includes("...") || config.contractId.startsWith("0x0000000000000000000000000000000000000000000000000000000000000000")) {
+      throw new Error(`Invalid contractId: placeholder or null address detected in configuration: "${config.contractId}".`);
+    }
     if (config.rpcUrl.includes("XCa...") || config.rpcUrl.includes("...")) {
       throw new Error("Invalid RPC URL: placeholder detected in configuration. Please provide a valid Soroban RPC provider URL.");
     }
     this.rpc = new SorobanRpc.Server(config.rpcUrl);
-    this.contract = new Contract(config.contractId);
+    this.contract = new Contract(config.contractId.trim());
     this.networkPassphrase = config.networkPassphrase;
-    this.contractId = config.contractId;
+    this.contractId = config.contractId.trim();
   }
 
   // === Read methods (no transaction needed)


### PR DESCRIPTION
### Summary
Fixes #659 by adding runtime validation for `contractId` in the `MergeMintSDK` constructor in `sdk/src/index.ts`.

### Solution
- Checks that `config.contractId` is present, non-empty, and a string.
- Guards against ellipsis placeholders (e.g. `C...`) or zero addresses.
- Prevents subtle downstream runtime errors or failed RPC calls when consumed from untyped JavaScript.

### Verification
Ensures invalid configurations fail immediately at initialization with informative diagnostics.

---
*Payout Address:* `0x4DF12f27bEDC11EDEAfa6154A193C65a329388DE`