### PR TITLE
feat(sdk): add typed MergeMintSdkError class with error codes (#660)

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -11,7 +11,7 @@ import {
 } from "@stellar/stellar-sdk";
 
 export * from "./types";
-import { NetworkConfig, Bounty, BountyMeta, Contributor, CreateBountyParams } from "./types";
+import { NetworkConfig, Bounty, BountyMeta, Contributor, CreateBountyParams, MergeMintSdkError } from "./types";
 
 export const TESTNET: Omit<NetworkConfig, "contractId"> = {
   rpcUrl: "https://soroban-testnet.stellar.org",
@@ -40,7 +40,7 @@ function addressToScVal(address: string): xdr.ScVal {
 
 function symbolToScVal(value: string): xdr.ScVal {
   if (value.length > 32) {
-    throw new Error(`value exceeds 32-character Symbol limit: ${value}`);
+    throw new MergeMintSdkError(`value exceeds 32-character Symbol limit: ${value}`, "INVALID_ARGUMENT");
   }
   return nativeToScVal(value, { type: "symbol" });
 }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -47,3 +47,26 @@ export interface CreateBountyParams {
   approvalThreshold?: number;
   milestones?: Array<{ description: string; reward: bigint; completed: boolean }>;
 }
+
+export type MergeMintErrorCode =
+  | 'INVALID_CONFIG'
+  | 'INVALID_CONTRACT_ID'
+  | 'INVALID_RPC_URL'
+  | 'INVALID_ARGUMENT'
+  | 'SIMULATION_FAILED'
+  | 'TRANSACTION_FAILED'
+  | 'UNAUTHORIZED'
+  | 'NOT_FOUND';
+
+export class MergeMintSdkError extends Error {
+  public readonly code: MergeMintErrorCode;
+  public readonly details?: unknown;
+
+  constructor(message: string, code: MergeMintErrorCode = 'INVALID_ARGUMENT', details?: unknown) {
+    super(message);
+    this.name = 'MergeMintSdkError';
+    this.code = code;
+    this.details = details;
+    Object.setPrototypeOf(this, MergeMintSdkError.prototype);
+  }
+}


### PR DESCRIPTION
### Summary
Fixes #660 by introducing a typed `MergeMintSdkError` class with structured error codes (`MergeMintErrorCode`) in `sdk/src/types.ts` and exporting it from the SDK.

### Changes
- Added `MergeMintSdkError` and `MergeMintErrorCode` union.
- Enabled programmatic error inspection via `err.code`.

### Verification
Maintains standard Error inheritance and prototype chain for robust `instanceof` checks.

---
*Payout Address:* `0x4DF12f27bEDC11EDEAfa6154A193C65a329388DE`