### PR TITLE
feat(sdk): export createNetworkConfig builder helper (#661)

### DIFF
--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -24,6 +24,23 @@ export const MAINNET: Omit<NetworkConfig, "contractId"> = {
   rpcUrl: "https://mainnet.stellar.validationcloud.io/v1/XCa...",
   networkPassphrase: Networks.PUBLIC,
 };
+
+/**
+ * Builds a full `NetworkConfig` by combining a base template (e.g. `TESTNET` or `MAINNET`)
+ * with a specific `contractId` and optional overrides.
+ */
+export function createNetworkConfig(
+  base: Omit<NetworkConfig, "contractId">,
+  contractId: string,
+  overrides?: Partial<Omit<NetworkConfig, "contractId">>
+): NetworkConfig {
+  return {
+    ...base,
+    contractId,
+    ...overrides,
+  };
+}
+
   rewardToken: string;
   minReputation: number;
   deadline: number | null;


### PR DESCRIPTION
### Summary
Fixes #661 by exporting a `createNetworkConfig` helper function in `sdk/src/index.ts` to conveniently instantiate `NetworkConfig` from preset environments (`TESTNET`, `MAINNET`) and custom overrides.

### Changes
- Added `createNetworkConfig(base, contractId, overrides)`.
- Ergonomic helper for SDK consumers setting up custom or test configurations.

### Verification
Type-checked interface mapping.

---
*Payout Address:* `0x4DF12f27bEDC11EDEAfa6154A193C65a329388DE`